### PR TITLE
Fix: rare case when a reward message arrives on the video port in the next mission.

### DIFF
--- a/Malmo/src/VideoServer.cpp
+++ b/Malmo/src/VideoServer.cpp
@@ -51,6 +51,12 @@ namespace malmo
     
     void VideoServer::handleMessage( TimestampedUnsignedCharVector message )
     {
+        if (message.data.size() != this->width * this->height * this->channels) 
+        {
+            // Have seen this happen during stress testing when a reward packet from (I think) a previous mission arrives during the next
+            // one when the same port has been reassigned. Could throw here but chose to silently ignore since very rare.
+            return;
+        }
         TimestampedVideoFrame frame(this->width, this->height, this->channels, message, TimestampedVideoFrame::REVERSE_SCANLINE);
         this->handle_frame(frame);
         


### PR DESCRIPTION
During stress testing I saw a rare case when a reward message was seen to arrive during the next mission, on the (now) video port. In that sort of case it is OK to just discard the message.

Are there cases where we want to deal with this situation differently?

Should we apply similar validation to the other channels? 
