### PR TITLE
Fix overclocking not applying to client in obfuscated environment

### DIFF
--- a/Minecraft/src/main/java/com/microsoft/Malmo/OverclockingClassTransformer.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/OverclockingClassTransformer.java
@@ -106,7 +106,7 @@ public class OverclockingClassTransformer implements IClassTransformer
     */
         // This allows us to alter the tick length via TimeHelper.
         
-        final String methodName = isObfuscated ? "minecraft" : "run";
+        final String methodName = "run";
         final String methodDescriptor = "()V"; // No params, returns void.
 
         System.out.println("MALMO: Found MinecraftServer, attempting to transform it");
@@ -141,7 +141,7 @@ public class OverclockingClassTransformer implements IClassTransformer
         //          TimeHelper.updateDisplay();
         // TimeHelper's method then decides whether or not to pass the call on to Minecraft.updateDisplay().
         
-        final String methodName = isObfuscated ? "av" : "runGameLoop";
+        final String methodName = isObfuscated ? "as" : "runGameLoop";
         final String methodDescriptor = "()V"; // No params, returns void.
 
         System.out.println("MALMO: Found Minecraft, attempting to transform it");
@@ -150,15 +150,19 @@ public class OverclockingClassTransformer implements IClassTransformer
         {
             if (method.name.equals(methodName) && method.desc.equals(methodDescriptor))
             {
-                System.out.println("MALMO: Found MinecraftServer.run() method, attempting to transform it");
+                System.out.println("MALMO: Found Minecraft.runGameLoop() method, attempting to transform it");
                 for (AbstractInsnNode instruction : method.instructions.toArray())
                 {
                     if (instruction.getOpcode() == Opcodes.INVOKEVIRTUAL)
                     {
                         MethodInsnNode visitMethodNode = (MethodInsnNode)instruction;
-                        if (visitMethodNode.name.equals("updateDisplay"))
+                        if (visitMethodNode.name.equals(isObfuscated ? "h" : "updateDisplay"))
                         {
                             visitMethodNode.owner = "com/microsoft/Malmo/Utils/TimeHelper";
+                            if (isObfuscated)
+                            {
+                                visitMethodNode.name = "updateDisplay";
+                            }
                             visitMethodNode.setOpcode(Opcodes.INVOKESTATIC);
                             method.instructions.remove(visitMethodNode.getPrevious());  // ALOAD 0 not needed for static invocation.
                             System.out.println("MALMO: Hooked into call to Minecraft.updateDisplay()");


### PR DESCRIPTION
Currently, the mod only correctly applies the overclocking to the client inside a deobfuscated environment (such as using gradlew runClient). Attempting to run this mod in an obfuscated environment (such as installing forge on a Minecraft installation) will not find the correct methods.

There were three sources of this issue:
1. runGameLoop was using a 1.8.8 obfuscated name, not a 1.8 obfuscated name
2. the name updateDisplay was being checked for without checking if it was obfuscated
3. it didn't change the obfuscated name to the correct name if it was in an obfuscated environment.

This PR fixes these three issues as well as an incorrect comment and a redundant ternary which finds the run method for the MinecraftServer.