### PR TITLE
Python frame speedup

### DIFF
--- a/Malmo/samples/Python_examples/ALE_HAC.py
+++ b/Malmo/samples/Python_examples/ALE_HAC.py
@@ -24,7 +24,7 @@ import sys
 import time
 import errno
 import Tkinter as tk
-#from PIL import Image, ImageTk - we need these for displaying our own gui, but it's a nightmare installing the dependencies correctly.
+from PIL import Image, ImageTk
 from array import array
 from struct import pack
 
@@ -192,14 +192,12 @@ def sendCommand():
             print "Error:",error.text
         if world_state.number_of_video_frames_since_last_state > 0 and want_own_display:
             # Turn the frame into an image to display on our canvas.
-            # On my system creating buff was too slow to be usable, whichever of these three apporaches I tried:
-            buff = str(bytearray(world_state.video_frames[-1].pixels))
-            # Or buff = pack('100800B', *(world_state.video_frames[-1].pixels))
-            # Or buff = array('B', world_state.video_frames[-1].pixels)
-            image = Image.frombytes('RGB', (320,420), buff)
+            frame = world_state.video_frames[-1]
+            buff = buffer(frame.pixels, 0, frame.width * frame.height * frame.channels)
+            image = Image.frombytes('RGB', (frame.width,frame.height), buff)
             photo = ImageTk.PhotoImage(image)
             canvas.delete("all")
-            canvas.create_image(80,105, image=photo)
+            canvas.create_image(frame.width/2, frame.height/2, image=photo)
             root.update()
 
     if world_state.is_mission_running:
@@ -237,7 +235,7 @@ want_own_display = agent_host.receivedArgument('own_display')
 iterations = agent_host.getIntArgument('goes')
 
 my_mission = MalmoPython.MissionSpec()
-my_mission.requestVideo( 210, 160 )
+my_mission.requestVideo( 160, 210 )
 
 recordingsDirectory = rom_file.rpartition('/')[-1]+'_recordings'
 try:

--- a/Malmo/src/PythonWrapper/python_module.cpp
+++ b/Malmo/src/PythonWrapper/python_module.cpp
@@ -87,6 +87,15 @@ struct ptime_to_python_datetime
     }
 };
 
+struct unsigned_char_vec_to_python_array
+{
+    static PyObject* convert(std::vector<unsigned char> const& vec)
+    {
+        const char* buffer = reinterpret_cast<const char*>(vec.data());
+        return PyByteArray_FromStringAndSize(buffer, vec.size());
+    }
+};
+
 // Defines the API available to Python.
 BOOST_PYTHON_MODULE(MalmoPython)
 {
@@ -95,6 +104,7 @@ BOOST_PYTHON_MODULE(MalmoPython)
     // Bind the converter for posix_time to python DateTime
     PyDateTime_IMPORT;
     to_python_converter<boost::posix_time::ptime, ptime_to_python_datetime>();
+    to_python_converter<std::vector<unsigned char>, unsigned_char_vec_to_python_array>();
 
     class_< ArgumentParser, boost::noncopyable >("ArgumentParser", init< const std::string& >())
         .def( "parse",                     &parsePythonList )
@@ -253,7 +263,7 @@ BOOST_PYTHON_MODULE(MalmoPython)
         .def_readonly( "width",       &TimestampedVideoFrame::width )
         .def_readonly( "height",      &TimestampedVideoFrame::height )
         .def_readonly( "channels",    &TimestampedVideoFrame::channels )
-        .def_readonly( "pixels",      &TimestampedVideoFrame::pixels )
+        .add_property( "pixels",      make_getter(&TimestampedVideoFrame::pixels, return_value_policy<return_by_value>()))
         .def(self_ns::str(self_ns::self))
     ;
     class_< std::vector< boost::shared_ptr< TimestampedString > > >( "TimestampedStringVector" )
@@ -264,9 +274,6 @@ BOOST_PYTHON_MODULE(MalmoPython)
     ;
     class_< std::vector< boost::shared_ptr< TimestampedVideoFrame > > >( "TimestampedVideoFrameVector" )
         .def( vector_indexing_suite< std::vector< boost::shared_ptr< TimestampedVideoFrame > >, true >() )
-    ;
-    class_< std::vector< unsigned char > >( "UnsignedCharVector")
-        .def( vector_indexing_suite< std::vector< unsigned char > >() )
     ;
     register_exception_translator<xml_schema::exception>(&translateXMLSchemaException);
 }


### PR DESCRIPTION
This fixes #187, amounting to a 100x speedup, which is nice.
Integration tests are all passing, but I shall leave a stress test running over the weekend to check this change doesn't introduce any memory leaks.