### PR TITLE
Added ability to query MissionSpec for the allowed commands and command handlers.

### DIFF
--- a/Malmo/samples/Python_examples/human_action.py
+++ b/Malmo/samples/Python_examples/human_action.py
@@ -51,30 +51,57 @@ class HumanAgentHost:
     def addOptionalStringArgument( self, name, description, default ):
         return self.agent_host.addOptionalStringArgument(name, description, default)
 
+    def addOptionalIntArgument( self, name, description, default ):
+        return self.agent_host.addOptionalIntArgument(name, description, default)
+
     def receivedArgument(self,arg):
         return self.agent_host.receivedArgument(arg)
 
     def getStringArgument(self,arg):
         return self.agent_host.getStringArgument(arg)
 
-    def runMission( self, mission_spec, mission_record_spec, action_space, summary = None ):
+    def getIntArgument(self,arg):
+        return self.agent_host.getIntArgument(arg)
+
+    def runMission( self, mission_spec, mission_record_spec, role = 0, summary = None ):
         '''Sets a mission running.
         
         Parameters:
         mission_spec : MissionSpec instance, specifying the mission.
         mission_record_spec : MissionRecordSpec instance, specifying what should be recorded.
-        action_space : string, either 'continuous' or 'discrete' that says which commands to generate.
+        summary : string, a short description of the mission to be shown to the user
         '''
         
         self.world_state = None
-        self.action_space = action_space
         total_reward = 0
+        
+        # decide on the action space
+        command_handlers = mission_spec.getListOfCommandHandlers(role)
+        if 'ContinuousMovement' in command_handlers and 'DiscreteMovement' in command_handlers:
+            print 'ERROR: Ambiguous action space in supplied mission: both continuous and discrete command handlers present.'
+            exit(1)
+        elif 'ContinuousMovement' in command_handlers:
+            self.action_space = 'continuous'
+        elif 'DiscreteMovement' in command_handlers:
+            self.action_space = 'discrete'
+        else:
+            print 'ERROR: Unknown action space in supplied mission: neither continuous or discrete command handlers present.'
+            exit(1)
 
         self.createGUI()
         
         if mission_spec.isVideoRequested(0):
             self.canvas.config( width=mission_spec.getVideoWidth(0), height=mission_spec.getVideoHeight(0) )
 
+        # show the mission summary
+        start_time = time.time()
+        while summary and time.time() - start_time < 4:
+            canvas_id = self.canvas.create_rectangle(100, 100, 540, 200, fill="white", outline="red", width="5")
+            self.canvas.create_text(320, 120, text=summary, font=('Helvetica', '16'))
+            self.canvas.create_text(320, 150, text=str(3 - int(time.time() - start_time)), font=('Helvetica', '16'), fill="red")
+            self.root.update()
+            time.sleep(0.2)
+                
         try:
             self.agent_host.startMission( mission_spec, mission_record_spec )
         except RuntimeError as e:
@@ -90,13 +117,12 @@ class HumanAgentHost:
             for error in self.world_state.errors:
                 print "Error:",error.text
         print
-        if action_space == 'continuous':
+        if self.action_space == 'continuous':
             self.canvas.config(cursor='none') # hide the mouse cursor while over the canvas
             self.canvas.event_generate('<Motion>', warp=True, x=self.canvas.winfo_width()/2, y=self.canvas.winfo_height()/2) # put cursor at center
             self.root.after(50, self.update)
         self.canvas.focus_set()
 
-        start_time = time.time()
         while self.world_state.is_mission_running:
             self.world_state = self.agent_host.getWorldState()
             if self.world_state.number_of_observations_since_last_state > 0:
@@ -109,18 +135,13 @@ class HumanAgentHost:
                 self.canvas.create_image(frame.width/2, frame.height/2, image=photo)
             self.canvas.create_line( self.canvas.winfo_width()/2-5, self.canvas.winfo_height()/2,   self.canvas.winfo_width()/2+6, self.canvas.winfo_height()/2,   fill='white' )
             self.canvas.create_line( self.canvas.winfo_width()/2,   self.canvas.winfo_height()/2-5, self.canvas.winfo_width()/2,   self.canvas.winfo_height()/2+6, fill='white' )
-            # print summary
-            if summary and time.time() - start_time < 4:
-                canvas_id = self.canvas.create_rectangle(100, 100, 540, 200, fill="white", outline="red", width="5")
-                self.canvas.create_text(320, 120, text=summary, font=('Helvetica', '16'))
-                self.canvas.create_text(320, 150, text=str(3 - int(time.time() - start_time)), font=('Helvetica', '16'), fill="red")
             # parse reward
             for reward in self.world_state.rewards:
                 total_reward += reward.getValue()
             self.reward.config(text = str(total_reward) )
             self.root.update()
             time.sleep(0.01)
-        if action_space == 'continuous':
+        if self.action_space == 'continuous':
             self.canvas.config(cursor='arrow') # restore the mouse cursor
         print 'Mission stopped'
         if not self.agent_host.receivedArgument("test"):
@@ -137,7 +158,7 @@ class HumanAgentHost:
         else:
             desc = "Running discrete-action mission.\nUse the arrow keys to turn and move."
         Label(self.root_frame, text=desc,font = our_font,wraplength=640).pack(padx=5, pady=5)
-        self.canvas = Canvas(self.root_frame, borderwidth=0, highlightthickness=0, width=640, height=480, bg="black" )
+        self.canvas = Canvas(self.root_frame, borderwidth=0, highlightthickness=0, width=640, height=480, bg="gray" )
         self.canvas.bind('<Motion>',self.onMouseMoveInCanvas)
         self.canvas.bind('<Button-1>',self.onLeftMouseDownInCanvas)
         self.canvas.bind('<ButtonRelease-1>',self.onLeftMouseUpInCanvas)
@@ -161,7 +182,7 @@ class HumanAgentHost:
         self.reward.pack()
         self.root_frame.pack()
         self.mouse_event = self.prev_mouse_event = None
-        
+ 
     def onSendCommand(self):
         '''Called when user presses the 'send' button or presses 'Enter' while the command entry box has focus.'''
         self.agent_host.sendCommand(self.command_entry.get())
@@ -248,8 +269,8 @@ class HumanAgentHost:
 sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)  # flush print output immediately
 
 human_agent_host = HumanAgentHost()
-human_agent_host.addOptionalStringArgument("mission_xml,m", "Mission XML file name.", "NULL")
-human_agent_host.addOptionalStringArgument("action_set,a", "Action set: discrete or continuous.", "continuous")
+human_agent_host.addOptionalStringArgument( "mission_xml,m", "Mission XML file name.", "" )
+human_agent_host.addOptionalIntArgument( "role", "The role of the human agent. Zero based", 0 )
 try:
     human_agent_host.parse( sys.argv )
 except RuntimeError as e:
@@ -259,14 +280,14 @@ except RuntimeError as e:
 if human_agent_host.receivedArgument("help"):
     print human_agent_host.getUsage()
     exit(0)
-
-# Run some missions as a demonstration. Replace this with your own missions.
+    
+my_role = human_agent_host.getIntArgument("role")
 
 xml = human_agent_host.getStringArgument("mission_xml")
-if xml  != "NULL":
+if not xml == "":
     with open(xml) as fh:
         lines = fh.readlines()
-        summary = None
+        summary = None # TODO: get summary from API rather than parsing the XML
         for line in lines:
             m = re.search("<Summary>([^<]+)", line)
             if m:
@@ -285,14 +306,11 @@ if xml  != "NULL":
         my_mission_record.recordRewards()
         my_mission_record.recordObservations()
 
-        action_space = human_agent_host.getStringArgument("action_set")
-        human_agent_host.runMission( my_mission, my_mission_record, action_space, summary )
+        human_agent_host.runMission( my_mission, my_mission_record, role = my_role, summary = summary )
 
 else:
 
     for rep in range(2):
-        action_space = [ 'discrete', 'continuous'][rep%2]
-
         my_mission = MalmoPython.MissionSpec()
         my_mission.requestVideo( 640, 480 )
         my_mission.timeLimitInSeconds( 30 )
@@ -302,11 +320,11 @@ else:
         my_mission.observeChat()
         my_mission.observeGrid( -1, -1, -1, 1, 1, 1, 'grid' )
         my_mission.observeHotBar()
-        my_mission.drawBlock( 5, 226, 5, 'lava' )
+        my_mission.drawBlock( 5, 226, 5, 'gold_block' )
         my_mission.rewardForReachingPosition( 5.5, 227, 5.5, 100, 0.5 )
         my_mission.endAt( 5.5, 227, 5.5, 0.5 )
         my_mission.startAt( 0.5, 227, 0.5 )
-        if action_space=='discrete':
+        if rep%2 == 1: # alternate between continuous and discrete missions, for fun
             my_mission.removeAllCommandHandlers()
             my_mission.allowAllDiscreteMovementCommands()
 
@@ -316,4 +334,4 @@ else:
         my_mission_record.recordRewards()
         my_mission_record.recordObservations()
 
-        human_agent_host.runMission( my_mission, my_mission_record, action_space )
+        human_agent_host.runMission( my_mission, my_mission_record, role = my_role, summary = 'A sample mission - run onto the gold block' )

--- a/Malmo/samples/Python_examples/human_action.py
+++ b/Malmo/samples/Python_examples/human_action.py
@@ -69,6 +69,7 @@ class HumanAgentHost:
         Parameters:
         mission_spec : MissionSpec instance, specifying the mission.
         mission_record_spec : MissionRecordSpec instance, specifying what should be recorded.
+        role : int, the index of the role this human agent is to play. Zero based.
         summary : string, a short description of the mission to be shown to the user
         '''
         

--- a/Malmo/src/CSharpWrapper/MalmoNETNative.i
+++ b/Malmo/src/CSharpWrapper/MalmoNETNative.i
@@ -370,6 +370,10 @@ public:
   int getVideoHeight(int role) const;
 
   int getVideoChannels(int role) const;
+  
+  std::vector< std::string > getListOfCommandHandlers(int role) const;
+  
+  std::vector< std::string > getAllowedCommands(int role,const std::string& ) const;
 };
 
 struct TimestampedString {

--- a/Malmo/src/JavaWrapper/MalmoJava.i
+++ b/Malmo/src/JavaWrapper/MalmoJava.i
@@ -356,6 +356,10 @@ public:
   int getVideoHeight(int role) const;
 
   int getVideoChannels(int role) const;
+
+  std::vector< std::string > getListOfCommandHandlers(int role) const;
+  
+  std::vector< std::string > getAllowedCommands(int role,const std::string& ) const;
 };
 
 struct TimestampedString {

--- a/Malmo/src/LuaWrapper/lua_module.cpp
+++ b/Malmo/src/LuaWrapper/lua_module.cpp
@@ -18,11 +18,10 @@
 // --------------------------------------------------------------------------------------------------
 
 // Malmo:
+#include <AgentHost.h>
 #ifdef WRAP_ALE
   #include <ALEAgentHost.h>
 #endif
-
-#include <AgentHost.h>
 #include <ClientPool.h>
 #include <MissionSpec.h>
 #include <ParameterSet.h>
@@ -36,7 +35,6 @@ using namespace malmo;
 #include <luabind/exception_handler.hpp>
 #include <luabind/iterator_policy.hpp>
 #include <luabind/luabind.hpp>
-#include <luabind/return_reference_to_policy.hpp>
 #include <luabind/operator.hpp>
 
 // STL:
@@ -98,6 +96,28 @@ void (AgentHost::*startMissionComplex)(const MissionSpec&, const ClientPool&, co
 void recordMP4(MissionRecordSpec* mrs, int frames_per_second, long bitrate)
 {
     mrs->recordMP4(frames_per_second,static_cast<int64_t>(bitrate));
+}
+
+// wrapper for MissionSpec::getListOfCommandHandlers that returns a table
+luabind::object getListOfCommandHandlers( lua_State *L, const MissionSpec& m, int role )
+{
+    luabind::object result = luabind::newtable(L);
+    int index = 1;
+    for( const std::string& ch : m.getListOfCommandHandlers( role ) ) {
+        result[ index++ ] = ch;
+    }
+    return result;
+}
+
+// wrapper for MissionSpec::getAllowedCommands that returns a table
+luabind::object getAllowedCommands( lua_State *L, const MissionSpec& m, int role, const std::string& command_handler )
+{
+    luabind::object result = luabind::newtable(L);
+    int index = 1;
+    for( const std::string& ac : m.getAllowedCommands( role, command_handler ) ) {
+        result[ index++ ] = ac;
+    }
+    return result;
 }
 
 // Defines the API available to Lua.
@@ -234,8 +254,8 @@ MODULE_EXPORT int luaopen_libMalmoLua(lua_State* L)
             .def("getVideoWidth",             &MissionSpec::getVideoWidth)
             .def("getVideoHeight",            &MissionSpec::getVideoHeight)
             .def("getVideoChannels",          &MissionSpec::getVideoChannels)
-            .def("getListOfCommandHandlers",  &MissionSpec::getListOfCommandHandlers)
-            .def("getAllowedCommands",        &MissionSpec::getAllowedCommands)
+            .def("getListOfCommandHandlers",  &getListOfCommandHandlers)
+            .def("getAllowedCommands",        &getAllowedCommands)
             .def(tostring(const_self))
         ,
         class_< MissionRecordSpec >("MissionRecordSpec")

--- a/Malmo/src/LuaWrapper/lua_module.cpp
+++ b/Malmo/src/LuaWrapper/lua_module.cpp
@@ -234,6 +234,8 @@ MODULE_EXPORT int luaopen_libMalmoLua(lua_State* L)
             .def("getVideoWidth",             &MissionSpec::getVideoWidth)
             .def("getVideoHeight",            &MissionSpec::getVideoHeight)
             .def("getVideoChannels",          &MissionSpec::getVideoChannels)
+            .def("getListOfCommandHandlers",  &MissionSpec::getListOfCommandHandlers)
+            .def("getAllowedCommands",        &MissionSpec::getAllowedCommands)
             .def(tostring(const_self))
         ,
         class_< MissionRecordSpec >("MissionRecordSpec")

--- a/Malmo/src/MissionSpec.cpp
+++ b/Malmo/src/MissionSpec.cpp
@@ -469,6 +469,46 @@ namespace malmo
         return vps->want_depth() ? 4 : 3;
     }
     
+    vector<string> MissionSpec::getListOfCommandHandlers(int role) const
+    {
+        vector<string> command_handlers;
+        AgentHandlers ah = this->mission->AgentSection()[role].AgentHandlers();
+        if( ah.ContinuousMovementCommands().present() )
+            command_handlers.push_back( "ContinuousMovement" );
+        if( ah.AbsoluteMovementCommands().present() )
+            command_handlers.push_back( "AbsoluteMovement" );
+        if( ah.DiscreteMovementCommands().present() )
+            command_handlers.push_back( "DiscreteMovement" );
+        if( ah.InventoryCommands().present() )
+            command_handlers.push_back( "Inventory" );
+        if( ah.ChatCommands().present() )
+            command_handlers.push_back( "Chat" );
+        if( ah.SimpleCraftCommands().present() )
+            command_handlers.push_back( "SimpleCraft" );
+        return command_handlers;
+    }
+
+    vector<string> MissionSpec::getAllowedCommands(int role,const string& command_handler) const
+    {
+        AgentHandlers ah = this->mission->AgentSection()[role].AgentHandlers();
+        vector<string> allowed_commands;
+        if( command_handler == "ContinuousMovement" && ah.ContinuousMovementCommands().present() ) {
+            const ContinuousMovementCommands& cmc = *ah.ContinuousMovementCommands();
+            vector<string> commands = { "move", "strafe", "pitch", "turn", "jump", "crouch", "attack", "use" };
+            if( cmc.ModifierList().present() ) {
+               const CommandListModifier& clm = *cmc.ModifierList();
+               switch( clm.type() ) {
+                   case type::allow_list: break;
+                   case type::deny_list: break;
+               }
+            }
+            else {
+                allowed_commands.insert( allowed_commands.end(), commands.begin(), commands.end() );
+            }
+        }
+        return allowed_commands;
+    }
+    
     // ---------------------------- private functions -----------------------------------------------
     
     void MissionSpec::putVerbOnList( ::xsd::cxx::tree::optional< ModifierList >& mlo

--- a/Malmo/src/MissionSpec.h
+++ b/Malmo/src/MissionSpec.h
@@ -301,10 +301,13 @@ namespace malmo
             friend std::ostream& operator<<(std::ostream& os, const MissionSpec& ms);
         private:
         
-            void putVerbOnList( ::xsd::cxx::tree::optional< malmo::schemas::ModifierList >& mlo
+            static void putVerbOnList( ::xsd::cxx::tree::optional< malmo::schemas::ModifierList >& mlo
                               , const std::string& verb
                               , const std::string& on_list
                               , const std::string& off_list );
+            static std::vector<std::string> getModifiedCommandList(
+                                const std::vector<std::string>& all_commands
+                              , const malmo::schemas::CommandListModifier& modifier_list );
         
             friend class MissionInitSpec;
         

--- a/Malmo/src/MissionSpec.h
+++ b/Malmo/src/MissionSpec.h
@@ -287,6 +287,17 @@ namespace malmo
             //! \returns The number of channels in the requested video: 3 for RGB, 4 for RGBD.
             int getVideoChannels(int role) const;
 
+            //! Returns a list of the names of the active command handlers for one of the agents involved in this mission.
+            //! \param role The agent index. Zero based.
+            //! \returns The list of command handler names: 'ContinuousMovement', 'DiscreteMovement', 'Chat', etc.
+            vector<string> MissionSpec::getListOfCommandHandlers(int role) const;
+
+            //! Returns a list of the names of the allowed commands for one of the agents involved in this mission.
+            //! \param role The agent index. Zero based.
+            //! \param command_handler The name of the command handler, as returned by getListOfCommandHandlers().
+            //! \returns The list of allowed commands: 'move', 'turn', 'attack', etc.
+            vector<string> MissionSpec::getAllowedCommands(int role,const string& command_handler) const;
+
             friend std::ostream& operator<<(std::ostream& os, const MissionSpec& ms);
         private:
         

--- a/Malmo/src/MissionSpec.h
+++ b/Malmo/src/MissionSpec.h
@@ -289,14 +289,14 @@ namespace malmo
 
             //! Returns a list of the names of the active command handlers for one of the agents involved in this mission.
             //! \param role The agent index. Zero based.
-            //! \returns The list of command handler names: 'ContinuousMovement', 'DiscreteMovement', 'Chat', etc.
-            vector<string> MissionSpec::getListOfCommandHandlers(int role) const;
+            //! \returns The list of command handler names: 'ContinuousMovement', 'DiscreteMovement', 'Chat', 'Inventory' etc.
+            std::vector<std::string> getListOfCommandHandlers(int role) const;
 
             //! Returns a list of the names of the allowed commands for one of the agents involved in this mission.
             //! \param role The agent index. Zero based.
             //! \param command_handler The name of the command handler, as returned by getListOfCommandHandlers().
-            //! \returns The list of allowed commands: 'move', 'turn', 'attack', etc.
-            vector<string> MissionSpec::getAllowedCommands(int role,const string& command_handler) const;
+            //! \returns The list of allowed commands: 'move', 'turn', 'attack' etc.
+            std::vector<std::string> getAllowedCommands(int role,const std::string& command_handler) const;
 
             friend std::ostream& operator<<(std::ostream& os, const MissionSpec& ms);
         private:

--- a/Malmo/src/PythonWrapper/python_module.cpp
+++ b/Malmo/src/PythonWrapper/python_module.cpp
@@ -209,6 +209,8 @@ BOOST_PYTHON_MODULE(MalmoPython)
         .def("getVideoWidth",             &MissionSpec::getVideoWidth)
         .def("getVideoHeight",            &MissionSpec::getVideoHeight)
         .def("getVideoChannels",          &MissionSpec::getVideoChannels)
+        .def("getListOfCommandHandlers",  &MissionSpec::getListOfCommandHandlers)
+        .def("getAllowedCommands",        &MissionSpec::getAllowedCommands)
         .def(self_ns::str(self_ns::self))
     ;
     class_< MissionRecordSpec >("MissionRecordSpec", init<>())
@@ -274,6 +276,9 @@ BOOST_PYTHON_MODULE(MalmoPython)
     ;
     class_< std::vector< boost::shared_ptr< TimestampedVideoFrame > > >( "TimestampedVideoFrameVector" )
         .def( vector_indexing_suite< std::vector< boost::shared_ptr< TimestampedVideoFrame > >, true >() )
+    ;
+    class_< std::vector< std::string > >( "StringVector" )
+        .def( vector_indexing_suite< std::vector< std::string >, true >() )
     ;
     register_exception_translator<xml_schema::exception>(&translateXMLSchemaException);
 }

--- a/Malmo/test/CppTests/test_mission.cpp
+++ b/Malmo/test/CppTests/test_mission.cpp
@@ -53,6 +53,34 @@ int main()
     my_mission.allowContinuousMovementCommand("strafe");
     my_mission.allowDiscreteMovementCommand("movenorth");
     my_mission.allowInventoryCommand("swapInventoryItems");
+    
+    const vector< string > expected_command_handlers = { "ContinuousMovement", "DiscreteMovement", "Inventory" };
+    if( my_mission.getListOfCommandHandlers(0) != expected_command_handlers )
+    {
+        cout << "Unexpected command handlers." << endl;
+        return EXIT_FAILURE;
+    }
+
+    const vector< string > expected_continuous_commands = { "move", "strafe" };
+    if( my_mission.getAllowedCommands(0,"ContinuousMovement") != expected_continuous_commands )
+    {
+        cout << "Unexpected commands for ContinuousMovement." << endl;
+        return EXIT_FAILURE;
+    }
+
+    const vector< string > expected_discrete_commands = { "movenorth" };
+    if( my_mission.getAllowedCommands(0,"DiscreteMovement") != expected_discrete_commands )
+    {
+        cout << "Unexpected commands for DiscreteMovement." << endl;
+        return EXIT_FAILURE;
+    }
+
+    const vector< string > expected_inventory_commands = { "swapInventoryItems" };
+    if( my_mission.getAllowedCommands(0,"Inventory") != expected_inventory_commands )
+    {
+        cout << "Unexpected commands for Inventory." << endl;
+        return EXIT_FAILURE;
+    }
 
     // check that the XML we produce validates
     const bool pretty_print = false;
@@ -78,7 +106,7 @@ int main()
     }
     
     // check that known-good XML validates
-    const string xml3 = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Mission xmlns=\"http://ProjectMalmo.microsoft.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://ProjectMalmo.microsoft.com Mission.xsd\">\
+    const string xml3 = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Mission xmlns=\"http://ProjectMalmo.microsoft.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\
         <About><Summary>Run the maze!</Summary></About>\
         <ServerSection><ServerInitialConditions><AllowSpawning>true</AllowSpawning><Time><StartTime>1000</StartTime><AllowPassageOfTime>true</AllowPassageOfTime></Time><Weather>clear</Weather></ServerInitialConditions>\
         <ServerHandlers>\
@@ -89,13 +117,27 @@ int main()
         <AgentSection><Name>Jason Bourne</Name><AgentStart><Placement x=\"-204\" y=\"81\" z=\"217\"/></AgentStart><AgentHandlers>\
         <VideoProducer want_depth=\"true\"><Width>320</Width><Height>240</Height></VideoProducer>\
         <RewardForReachingPosition><Marker reward=\"100\" tolerance=\"1.1\" x=\"-104\" y=\"81\" z=\"217\"/></RewardForReachingPosition>\
-        <ContinuousMovementCommands />\
+        <ContinuousMovementCommands><ModifierList type=\"deny-list\"><command>attack</command><command>crouch</command></ModifierList></ContinuousMovementCommands>\
         <AgentQuitFromReachingPosition><Marker x=\"-104\" y=\"81\" z=\"217\"/></AgentQuitFromReachingPosition>\
         </AgentHandlers></AgentSection></Mission>";
     try 
     {
         const bool validate = true;
         MissionSpec my_mission3( xml3, validate );
+        
+        const vector< string > expected_command_handlers = { "ContinuousMovement" };
+        if( my_mission3.getListOfCommandHandlers(0) != expected_command_handlers )
+        {
+            cout << "Unexpected command handlers in xml3." << endl;
+            return EXIT_FAILURE;
+        }
+
+        const vector< string > expected_continuous_commands = { "jump", "move", "pitch", "strafe", "turn", "use" };
+        if( my_mission3.getAllowedCommands(0,"ContinuousMovement") != expected_continuous_commands )
+        {
+            cout << "Unexpected commands for ContinuousMovement in xml3." << endl;
+            return EXIT_FAILURE;
+        }
     } 
     catch( const xml_schema::exception& e )
     {

--- a/Malmo/test/JavaTests/test_mission.java
+++ b/Malmo/test/JavaTests/test_mission.java
@@ -45,7 +45,63 @@ public class test_mission
         my_mission.observeFullInventory();
         my_mission.observeGrid(-2,0,-2,2,1,2, "Cells");
         my_mission.observeDistance(19.5f,0.0f,19.5f,"Goal");
-        my_mission.allowAllDiscreteMovementCommands();
+        my_mission.removeAllCommandHandlers();
+        my_mission.allowContinuousMovementCommand("move");
+        my_mission.allowContinuousMovementCommand("strafe");
+        my_mission.allowDiscreteMovementCommand("movenorth");
+        my_mission.allowInventoryCommand("swapInventoryItems");
+
+        String[] expected_command_handlers = { "ContinuousMovement", "DiscreteMovement", "Inventory" };
+        StringVector actual_command_handlers = my_mission.getListOfCommandHandlers(0);
+        if( actual_command_handlers.size() != expected_command_handlers.length ) {
+            System.out.println("Number of command handlers mismatch");
+            System.exit(1);
+        }
+        for( int i = 0; i < actual_command_handlers.size(); i++ ) {
+            if( !actual_command_handlers.get(i).equals( expected_command_handlers[i] ) ) {
+                System.out.println("Unexpected command handler: " + actual_command_handlers.get(i) );
+                System.exit(1);
+            }
+        }
+
+        String[] expected_continuous_commands = { "move", "strafe" };
+        StringVector actual_continuous_commands = my_mission.getAllowedCommands(0,"ContinuousMovement");
+        if( actual_continuous_commands.size() != expected_continuous_commands.length ) {
+            System.out.println("Number of continuous commands mismatch");
+            System.exit(1);
+        }
+        for( int i = 0; i < actual_continuous_commands.size(); i++ ) {
+            if( !actual_continuous_commands.get(i).equals( expected_continuous_commands[i] ) ) {
+                System.out.println("Unexpected continuous command: " + actual_continuous_commands.get(i) );
+                System.exit(1);
+            }
+        }
+
+        String[] expected_discrete_commands = { "movenorth" };
+        StringVector actual_discrete_commands = my_mission.getAllowedCommands(0,"DiscreteMovement");
+        if( actual_discrete_commands.size() != expected_discrete_commands.length ) {
+            System.out.println("Number of discrete commands mismatch");
+            System.exit(1);
+        }
+        for( int i = 0; i < actual_discrete_commands.size(); i++ ) {
+            if( !actual_discrete_commands.get(i).equals( expected_discrete_commands[i] ) ) {
+               System.out.println("Unexpected discrete command: " + actual_discrete_commands.get(i) );
+                System.exit(1);
+            }
+        }
+
+        String[] expected_inventory_commands = { "swapInventoryItems" };
+        StringVector actual_inventory_commands = my_mission.getAllowedCommands(0,"Inventory");
+        if( actual_inventory_commands.size() != expected_inventory_commands.length ) {
+            System.out.println("Number of commands mismatch");
+            System.exit(1);
+        }
+        for( int i = 0; i < actual_inventory_commands.size(); i++ ) {
+            if( !actual_inventory_commands.get(i).equals( expected_inventory_commands[i] ) ) {
+                System.out.println("Unexpected command: " + actual_inventory_commands.get(i) );
+                System.exit(1);
+            }
+        }
 
         // check that the XML we produce validates
         boolean pretty_print = false;
@@ -70,7 +126,7 @@ public class test_mission
         }
         
         // check that known-good XML validates
-        String xml3 = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Mission xmlns=\"http://ProjectMalmo.microsoft.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://ProjectMalmo.microsoft.com Mission.xsd\">"
+        String xml3 = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Mission xmlns=\"http://ProjectMalmo.microsoft.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
             +"<About><Summary>Run the maze!</Summary></About>"
             +"<ServerSection><ServerInitialConditions><AllowSpawning>true</AllowSpawning><Time><StartTime>1000</StartTime><AllowPassageOfTime>true</AllowPassageOfTime></Time><Weather>clear</Weather></ServerInitialConditions>"
             +"<ServerHandlers>"
@@ -81,13 +137,39 @@ public class test_mission
             +"<AgentSection><Name>Jason Bourne</Name><AgentStart><Placement x=\"-204\" y=\"81\" z=\"217\"/></AgentStart><AgentHandlers>"
             +"<VideoProducer want_depth=\"true\"><Width>320</Width><Height>240</Height></VideoProducer>"
             +"<RewardForReachingPosition><Marker reward=\"100\" tolerance=\"1.1\" x=\"-104\" y=\"81\" z=\"217\"/></RewardForReachingPosition>"
-            +"<ContinuousMovementCommands />"
+            +"<ContinuousMovementCommands><ModifierList type=\"deny-list\"><command>attack</command><command>crouch</command></ModifierList></ContinuousMovementCommands>"
             +"<AgentQuitFromReachingPosition><Marker x=\"-104\" y=\"81\" z=\"217\"/></AgentQuitFromReachingPosition>"
             +"</AgentHandlers></AgentSection></Mission>";
         try 
         {
             boolean validate = true;
             MissionSpec my_mission3 = new MissionSpec( xml3, validate );
+            
+            String[] expected_command_handlers2 = { "ContinuousMovement" };
+            StringVector actual_command_handlers2 = my_mission3.getListOfCommandHandlers(0);
+            if( actual_command_handlers2.size() != expected_command_handlers2.length ) {
+                System.out.println("Number of command handlers mismatch");
+                System.exit(1);
+            }
+            for( int i = 0; i < actual_command_handlers2.size(); i++ ) {
+                if( !actual_command_handlers2.get(i).equals( expected_command_handlers2[i] ) ) {
+                    System.out.println("Unexpected command handler: " + actual_command_handlers2.get(i) );
+                    System.exit(1);
+                }
+            }
+
+            String[] expected_continuous_commands2 = { "jump", "move", "pitch", "strafe", "turn", "use" };
+            StringVector actual_continuous_commands2 = my_mission3.getAllowedCommands(0,"ContinuousMovement");
+            if( actual_continuous_commands2.size() != expected_continuous_commands2.length ) {
+                System.out.println("Number of continuous commands mismatch");
+                System.exit(1);
+            }
+            for( int i = 0; i < actual_continuous_commands2.size(); i++ ) {
+                if( !actual_continuous_commands2.get(i).equals( expected_continuous_commands2[i] ) ) {
+                    System.out.println("Unexpected continuous command: " + actual_continuous_commands2.get(i) );
+                    System.exit(1);
+                }
+            }
         } 
         catch( Exception e )
         {

--- a/Malmo/test/LuaTests/test_mission.lua
+++ b/Malmo/test/LuaTests/test_mission.lua
@@ -44,25 +44,23 @@ my_mission:allowContinuousMovementCommand("strafe");
 my_mission:allowDiscreteMovementCommand("movenorth");
 my_mission:allowInventoryCommand("swapInventoryItems");
 
-if not list( my_mission.getListOfCommandHandlers(0) ) == [ 'ContinuousMovement', 'DiscreteMovement', 'Inventory' ] then
-    print('Unexpected command handlers')
-    os.exit(1)
+function tablesAreEqual(t1, t2)
+  -- assumes tables are not nested
+  if #t1 ~= #t2 then return false end
+  for i=1,#t1 do
+    if t1[i] ~= t2[i] then return false end
+  end
+  return true
 end
 
-if not list( my_mission.getAllowedCommands(0,'ContinuousMovement') ) == [ 'move', 'strafe' ] then
-    print 'Unexpected continuous command'
-    os.exit(1)
-end
-
-if not list( my_mission.getAllowedCommands(0,'DiscreteMovement') ) == [ 'movenorth' ] then
-    print 'Unexpected discrete command'
-    os.exit(1)
-end
-
-if not list( my_mission.getAllowedCommands(0,'Inventory') ) == [ 'swapInventoryItems' ] then
-    print 'Unexpected inventory command'
-    os.exit(1)
-end
+assert( tablesAreEqual( my_mission:getListOfCommandHandlers(0),
+        { "ContinuousMovement", "DiscreteMovement", "Inventory" } ), "Unexpected command handlers." )
+assert( tablesAreEqual( my_mission:getAllowedCommands(0,"ContinuousMovement"),
+        { "move", "strafe" } ), "Unexpected continuous commands." )
+assert( tablesAreEqual( my_mission:getAllowedCommands(0,"DiscreteMovement"),
+        { "movenorth" } ), "Unexpected discrete commands." )
+assert( tablesAreEqual( my_mission:getAllowedCommands(0,"Inventory"),
+        { "swapInventoryItems" } ), "Unexpected inventory commands." )
 
 local pretty_print = false
 local xml = my_mission:getAsXML( pretty_print )
@@ -74,3 +72,26 @@ local my_mission2 = MissionSpec( xml, validate )
 -- check that we get the same XML if we go round again
 local xml2 = my_mission2:getAsXML( pretty_print )
 assert( xml2 == xml, 'Mismatch between first generation XML and the second:\n'..xml..'\n\n'..xml2 )
+
+-- check that known-good XML validates
+local xml3 = '<?xml version=\"1.0\" encoding=\"UTF-8\" ?><Mission xmlns=\"http://ProjectMalmo.microsoft.com\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">' ..
+    '<About><Summary>Run the maze!</Summary></About>' ..
+    '<ServerSection><ServerInitialConditions><AllowSpawning>true</AllowSpawning><Time><StartTime>1000</StartTime><AllowPassageOfTime>true</AllowPassageOfTime></Time><Weather>clear</Weather></ServerInitialConditions>' ..
+    '<ServerHandlers>' ..
+    '<FlatWorldGenerator generatorString=\"3;7,220*1,5*3,2;3;,biome_1\" />' ..
+    '<ServerQuitFromTimeUp timeLimitMs=\"20000\" />' ..
+    '<ServerQuitWhenAnyAgentFinishes />' ..
+    '</ServerHandlers></ServerSection>' ..
+    '<AgentSection><Name>Jason Bourne</Name><AgentStart><Placement x=\"-204\" y=\"81\" z=\"217\"/></AgentStart><AgentHandlers>' ..
+    '<VideoProducer want_depth=\"true\"><Width>320</Width><Height>240</Height></VideoProducer>' ..
+    '<RewardForReachingPosition><Marker reward=\"100\" tolerance=\"1.1\" x=\"-104\" y=\"81\" z=\"217\"/></RewardForReachingPosition>' ..
+    '<ContinuousMovementCommands><ModifierList type=\"deny-list\"><command>attack</command><command>crouch</command></ModifierList></ContinuousMovementCommands>' ..
+    '<AgentQuitFromReachingPosition><Marker x=\"-104\" y=\"81\" z=\"217\"/></AgentQuitFromReachingPosition>' ..
+    '</AgentHandlers></AgentSection></Mission>'
+local my_mission3 = MissionSpec( xml3, validate )
+
+assert( tablesAreEqual( my_mission3:getListOfCommandHandlers(0),
+        { "ContinuousMovement" } ), "Unexpected command handlers." )
+assert( tablesAreEqual( my_mission3:getAllowedCommands(0,"ContinuousMovement"),
+        { "jump", "move", "pitch", "strafe", "turn", "use" } ), "Unexpected continuous commands." )
+

--- a/Malmo/test/LuaTests/test_mission.lua
+++ b/Malmo/test/LuaTests/test_mission.lua
@@ -38,7 +38,31 @@ my_mission:observeHotBar()
 my_mission:observeFullInventory()
 my_mission:observeGrid(-2,0,-2,2,1,2,"Cells")
 my_mission:observeDistance(19.5,0.0,19.5,"Goal")
-my_mission:allowAllDiscreteMovementCommands()
+my_mission:removeAllCommandHandlers();
+my_mission:allowContinuousMovementCommand("move");
+my_mission:allowContinuousMovementCommand("strafe");
+my_mission:allowDiscreteMovementCommand("movenorth");
+my_mission:allowInventoryCommand("swapInventoryItems");
+
+if not list( my_mission.getListOfCommandHandlers(0) ) == [ 'ContinuousMovement', 'DiscreteMovement', 'Inventory' ] then
+    print('Unexpected command handlers')
+    os.exit(1)
+end
+
+if not list( my_mission.getAllowedCommands(0,'ContinuousMovement') ) == [ 'move', 'strafe' ] then
+    print 'Unexpected continuous command'
+    os.exit(1)
+end
+
+if not list( my_mission.getAllowedCommands(0,'DiscreteMovement') ) == [ 'movenorth' ] then
+    print 'Unexpected discrete command'
+    os.exit(1)
+end
+
+if not list( my_mission.getAllowedCommands(0,'Inventory') ) == [ 'swapInventoryItems' ] then
+    print 'Unexpected inventory command'
+    os.exit(1)
+end
 
 local pretty_print = false
 local xml = my_mission:getAsXML( pretty_print )

--- a/Malmo/test/PythonTests/test_mission.py
+++ b/Malmo/test/PythonTests/test_mission.py
@@ -39,6 +39,27 @@ my_mission.observeFullInventory()
 my_mission.observeGrid(-2,0,-2,2,1,2,"Cells")
 my_mission.observeDistance(19.5,0.0,19.5,"Goal")
 my_mission.allowAllDiscreteMovementCommands()
+my_mission.removeAllCommandHandlers()
+my_mission.allowContinuousMovementCommand("move")
+my_mission.allowContinuousMovementCommand("strafe")
+my_mission.allowDiscreteMovementCommand("movenorth")
+my_mission.allowInventoryCommand("swapInventoryItems")
+
+if not list( my_mission.getListOfCommandHandlers(0) ) == [ 'ContinuousMovement', 'DiscreteMovement', 'Inventory' ]:
+    print 'Unexpected command handlers'
+    exit(1)
+
+if not list( my_mission.getAllowedCommands(0,'ContinuousMovement') ) == [ 'move', 'strafe' ]:
+    print 'Unexpected continuous command'
+    exit(1)
+
+if not list( my_mission.getAllowedCommands(0,'DiscreteMovement') ) == [ 'movenorth' ]:
+    print 'Unexpected discrete command'
+    exit(1)
+
+if not list( my_mission.getAllowedCommands(0,'Inventory') ) == [ 'swapInventoryItems' ]:
+    print 'Unexpected inventory command'
+    exit(1)
 
 pretty_print = False
 xml = my_mission.getAsXML( pretty_print )
@@ -51,4 +72,29 @@ my_mission2 = MalmoPython.MissionSpec( xml, validate )
 xml2 = my_mission2.getAsXML( pretty_print )
 if not xml2 == xml:
     print 'Mismatch between first generation XML and the second:\n', xml, '\n\n', xml2
+    exit(1)
+    
+# check that known-good XML validates
+xml3 = ('<?xml version="1.0" encoding="UTF-8" ?><Mission xmlns="http://ProjectMalmo.microsoft.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+        '<About><Summary>Run the maze!</Summary></About>'
+        '<ServerSection><ServerInitialConditions><AllowSpawning>true</AllowSpawning><Time><StartTime>1000</StartTime><AllowPassageOfTime>true</AllowPassageOfTime></Time><Weather>clear</Weather></ServerInitialConditions>'
+        '<ServerHandlers>'
+        '<FlatWorldGenerator generatorString="3;7,220*1,5*3,2;3;,biome_1" />'
+        '<ServerQuitFromTimeUp timeLimitMs="20000" />'
+        '<ServerQuitWhenAnyAgentFinishes />'
+        '</ServerHandlers></ServerSection>'
+        '<AgentSection><Name>Jason Bourne</Name><AgentStart><Placement x="-204" y="81" z="217"/></AgentStart><AgentHandlers>'
+        '<VideoProducer want_depth="true"><Width>320</Width><Height>240</Height></VideoProducer>'
+        '<RewardForReachingPosition><Marker reward="100" tolerance="1.1" x="-104" y="81" z="217"/></RewardForReachingPosition>'
+        '<ContinuousMovementCommands><ModifierList type="deny-list"><command>attack</command><command>crouch</command></ModifierList></ContinuousMovementCommands>'
+        '<AgentQuitFromReachingPosition><Marker x="-104" y="81" z="217"/></AgentQuitFromReachingPosition>'
+        '</AgentHandlers></AgentSection></Mission>')
+my_mission3 = MalmoPython.MissionSpec( xml3, validate )
+
+if not list( my_mission3.getListOfCommandHandlers(0) ) == [ 'ContinuousMovement' ]:
+    print 'Unexpected command handlers'
+    exit(1)
+
+if not list( my_mission3.getAllowedCommands(0,'ContinuousMovement') ) == [ "jump", "move", "pitch", "strafe", "turn", "use" ]:
+    print 'Unexpected continuous command'
     exit(1)

--- a/Schemas/Mission.xsd
+++ b/Schemas/Mission.xsd
@@ -338,6 +338,7 @@
             <xs:element ref="InventoryCommands" minOccurs="0"/>
             <xs:element ref="ChatCommands" minOccurs="0"/>
             <xs:element ref="SimpleCraftCommands" minOccurs="0"/>
+            <!-- When adding a new command handler, make sure to update MissionSpec::getListOfCommandHandlers -->
 
             <xs:element ref="AgentQuitFromTimeUp" minOccurs="0" />
             <xs:element ref="AgentQuitFromReachingPosition" minOccurs="0" />

--- a/Schemas/Mission.xsd
+++ b/Schemas/Mission.xsd
@@ -348,7 +348,7 @@
             <xs:element ref="InventoryCommands" minOccurs="0"/>
             <xs:element ref="ChatCommands" minOccurs="0"/>
             <xs:element ref="SimpleCraftCommands" minOccurs="0"/>
-            <!-- When adding a new command handler, make sure to update MissionSpec::getListOfCommandHandlers -->
+            <!-- When adding a new command handler, make sure to update MissionSpec::getListOfCommandHandlers and MissionSpec::getAllowedCommands -->
 
             <xs:element ref="AgentQuitFromTimeUp" minOccurs="0" />
             <xs:element ref="AgentQuitFromReachingPosition" minOccurs="0" />

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -742,6 +742,7 @@
       <xs:enumeration value="crouch" />
       <xs:enumeration value="attack" />
       <xs:enumeration value="use" />
+      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -770,6 +771,7 @@
       <xs:enumeration value="tp"/>
       <xs:enumeration value="setYaw" />
       <xs:enumeration value="setPitch" />
+      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -804,6 +806,7 @@
       <xs:enumeration value="movewest" />
       <xs:enumeration value="jump" />
       <xs:enumeration value="look" />
+      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -854,6 +857,7 @@
       <xs:enumeration value="hotbar.7" />
       <xs:enumeration value="hotbar.8" />
       <xs:enumeration value="hotbar.9" />
+      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -877,6 +881,7 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
         <xs:enumeration value="craft" />
+        <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -892,6 +897,7 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="chat" />
+      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -742,7 +742,6 @@
       <xs:enumeration value="crouch" />
       <xs:enumeration value="attack" />
       <xs:enumeration value="use" />
-      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -771,7 +770,6 @@
       <xs:enumeration value="tp"/>
       <xs:enumeration value="setYaw" />
       <xs:enumeration value="setPitch" />
-      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -812,7 +810,6 @@
       <xs:enumeration value="look" />
       <xs:enumeration value="attack" />
       <xs:enumeration value="use" />
-      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -863,7 +860,6 @@
       <xs:enumeration value="hotbar.7" />
       <xs:enumeration value="hotbar.8" />
       <xs:enumeration value="hotbar.9" />
-      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -887,7 +883,6 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
         <xs:enumeration value="craft" />
-        <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 
@@ -903,7 +898,6 @@
     </xs:annotation>
     <xs:restriction base="xs:string">
       <xs:enumeration value="chat" />
-      <!-- When modifying the commands, make sure to update MissionSpec::getAllowedCommands -->
     </xs:restriction>
   </xs:simpleType>
 

--- a/sample_missions/cliff_walking_1.xml
+++ b/sample_missions/cliff_walking_1.xml
@@ -45,11 +45,11 @@
           <Width>640</Width>
           <Height>480</Height>
       </VideoProducer>
-      <ContinuousMovementCommands turnSpeedDegs="240">
+      <DiscreteMovementCommands>
           <ModifierList type="deny-list">
             <command>attack</command>
           </ModifierList>
-      </ContinuousMovementCommands>
+      </DiscreteMovementCommands>
       <RewardForTouchingBlockType>
         <Block reward="-100.0" type="lava" behaviour="onceOnly"/>
         <Block reward="100.0" type="lapis_block" behaviour="onceOnly"/>


### PR DESCRIPTION
New API functions:
```
vector<string> MissionSpec::getListOfCommandHandlers() const;
vector<string> MissionSpec::getAllowedCommands(const string& command_handler) const;
```

Human action component no longer needs to be told the action space.

This closes #217.