### PR TITLE
Adding a 'quit' command to allow the agent to end the mission at any time.

### DIFF
--- a/Malmo/samples/Python_examples/mission_quit_command_example.py
+++ b/Malmo/samples/Python_examples/mission_quit_command_example.py
@@ -1,0 +1,115 @@
+# ------------------------------------------------------------------------------------------------
+# Copyright (c) 2016 Microsoft Corporation
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+# associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute,
+# sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all copies or
+# substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+# NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+# DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ------------------------------------------------------------------------------------------------
+
+# Quit command example
+
+import MalmoPython
+import os
+import sys
+import time
+
+sys.stdout = os.fdopen(sys.stdout.fileno(), 'w', 0)  # flush print output immediately
+
+# More interesting generator string: "3;7,44*49,73,35:1,159:4,95:13,35:13,159:11,95:10,159:14,159:6,35:6,95:6;12;"
+
+missionXML='''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+            <Mission xmlns="http://ProjectMalmo.microsoft.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            
+              <About>
+                <Summary>Hello world!</Summary>
+              </About>
+              
+              <ServerSection>
+                <ServerHandlers>
+                  <FlatWorldGenerator generatorString="3;7,220*1,5*3,2;3;,biome_1"/>
+                  <ServerQuitFromTimeUp timeLimitMs="30000"/>
+                  <ServerQuitWhenAnyAgentFinishes/>
+                </ServerHandlers>
+              </ServerSection>
+              
+              <AgentSection mode="Survival">
+                <Name>MalmoTutorialBot</Name>
+                <AgentStart/>
+                <AgentHandlers>
+                  <ObservationFromFullStats/>
+                  <ContinuousMovementCommands turnSpeedDegs="180"/>
+                  <ChatCommands />
+                  <MissionQuitCommands />
+                </AgentHandlers>
+              </AgentSection>
+            </Mission>'''
+
+# Create default Malmo objects:
+
+agent_host = MalmoPython.AgentHost()
+try:
+    agent_host.parse( sys.argv )
+except RuntimeError as e:
+    print 'ERROR:',e
+    print agent_host.getUsage()
+    exit(1)
+if agent_host.receivedArgument("help"):
+    print agent_host.getUsage()
+    exit(0)
+
+my_mission = MalmoPython.MissionSpec(missionXML, True)
+my_mission_record = MalmoPython.MissionRecordSpec()
+
+# Attempt to start a mission:
+max_retries = 3
+for retry in range(max_retries):
+    try:
+        agent_host.startMission( my_mission, my_mission_record )
+        break
+    except RuntimeError as e:
+        if retry == max_retries - 1:
+            print "Error starting mission:",e
+            exit(1)
+        else:
+            time.sleep(2)
+
+# Loop until mission starts:
+print "Waiting for the mission to start ",
+world_state = agent_host.getWorldState()
+while not world_state.is_mission_running:
+    sys.stdout.write(".")
+    time.sleep(0.1)
+    world_state = agent_host.getWorldState()
+    for error in world_state.errors:
+        print "Error:",error.text
+
+print
+print "Mission running ",
+
+count = 0
+
+# Loop until mission ends:
+while world_state.is_mission_running:
+    sys.stdout.write(".")
+    time.sleep(0.5)
+    if count > 10:
+        agent_host.sendCommand("quit")
+    count += 1
+    world_state = agent_host.getWorldState()
+    for error in world_state.errors:
+        print "Error:",error.text
+
+print
+print "Mission ended"
+# Mission has ended.

--- a/Malmo/src/MissionSpec.cpp
+++ b/Malmo/src/MissionSpec.cpp
@@ -362,6 +362,7 @@ namespace malmo
         this->mission->AgentSection().front().AgentHandlers().AbsoluteMovementCommands().reset();
         this->mission->AgentSection().front().AgentHandlers().InventoryCommands().reset();
         this->mission->AgentSection().front().AgentHandlers().ChatCommands().reset();
+        this->mission->AgentSection().front().AgentHandlers().MissionQuitCommands().reset();
     }
 
     void MissionSpec::allowAllContinuousMovementCommands()
@@ -495,6 +496,8 @@ namespace malmo
             command_handlers.push_back( "Chat" );
         if( ah.SimpleCraftCommands().present() )
             command_handlers.push_back( "SimpleCraft" );
+        if( ah.MissionQuitCommands().present() )
+            command_handlers.push_back( "MissionQuit" );
         return command_handlers;
     }
     
@@ -540,6 +543,13 @@ namespace malmo
             vector<string> commands( begin(SimpleCraftCommand::_xsd_SimpleCraftCommand_literals_), end(SimpleCraftCommand::_xsd_SimpleCraftCommand_literals_) );
             if( ah.SimpleCraftCommands()->ModifierList().present() )
                 return getModifiedCommandList( commands, *ah.SimpleCraftCommands()->ModifierList() );
+            else
+                return commands;
+        }
+        else if( command_handler == "MissionQuit" && ah.MissionQuitCommands().present() ) {
+            vector<string> commands( begin(MissionQuitCommand::_xsd_MissionQuitCommand_literals_), end(MissionQuitCommand::_xsd_MissionQuitCommand_literals_) );
+            if( ah.MissionQuitCommands()->ModifierList().present() )
+                return getModifiedCommandList( commands, *ah.MissionQuitCommands()->ModifierList() );
             else
                 return commands;
         }

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/MissionBehaviour.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/MissionBehaviour.java
@@ -146,24 +146,25 @@ public class MissionBehaviour
         // won't have to be added to often, if at all.
         if (handler == null)
             return;
-        
+
         if (handler instanceof IVideoProducer)
             addVideoProducer((IVideoProducer)handler);
-        else if (handler instanceof IAudioProducer)
+        if (handler instanceof IAudioProducer)
             addAudioProducer((IAudioProducer)handler);
-        else if (handler instanceof ICommandHandler)
+        if (handler instanceof ICommandHandler)
             addCommandHandler((ICommandHandler)handler);
-        else if (handler instanceof IObservationProducer)
+        if (handler instanceof IObservationProducer)
             addObservationProducer((IObservationProducer)handler);
-        else if (handler instanceof IRewardProducer)
+        if (handler instanceof IRewardProducer)
             addRewardProducer((IRewardProducer)handler);
-        else if (handler instanceof IWorldGenerator)
+        if (handler instanceof IWorldGenerator)
         	addWorldGenerator((IWorldGenerator)handler);
-        else if (handler instanceof IWorldDecorator)
-            addWorldDecorator((IWorldDecorator)handler);
-        else if (handler instanceof IWantToQuit)
+        if (handler instanceof IWorldDecorator)
+        	addWorldDecorator((IWorldDecorator)handler);
+        if (handler instanceof IWantToQuit)
             addQuitProducer((IWantToQuit)handler);
-        else
+
+        if (! (handler instanceof IVideoProducer || handler instanceof IAudioProducer || handler instanceof ICommandHandler || handler instanceof IObservationProducer || handler instanceof IRewardProducer || handler instanceof IWorldGenerator || handler instanceof IWorldDecorator || handler instanceof IWantToQuit))
             this.failedHandlers += handler.getClass().getSimpleName() + " isn't of a recognised handler type.\n";
     }
     

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/MissionQuitCommandsImplementation.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/MissionQuitCommandsImplementation.java
@@ -1,0 +1,112 @@
+// --------------------------------------------------------------------------------------------------
+//  Copyright (c) 2016 Microsoft Corporation
+//  
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+//  associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute,
+//  sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//  
+//  The above copyright notice and this permission notice shall be included in all copies or
+//  substantial portions of the Software.
+//  
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// --------------------------------------------------------------------------------------------------
+
+package com.microsoft.Malmo.MissionHandlers;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+
+import com.microsoft.Malmo.MissionHandlerInterfaces.ICommandHandler;
+import com.microsoft.Malmo.MissionHandlerInterfaces.IWantToQuit;
+import com.microsoft.Malmo.Schemas.MissionInit;
+import com.microsoft.Malmo.Schemas.MissionQuitCommand;
+import com.microsoft.Malmo.Schemas.MissionQuitCommands;
+
+/** Quit command allows for the agent to abort its mission at any time. */
+public class MissionQuitCommandsImplementation extends CommandBase implements ICommandHandler, IWantToQuit
+{
+    private boolean isOverriding;
+    private boolean iWantToQuit;	
+
+    @Override
+    protected boolean onExecute(String verb, String parameter, MissionInit missionInit)
+    {
+        EntityPlayerSP player = Minecraft.getMinecraft().thePlayer;
+        if (player == null)
+        {
+            return false;
+        }
+        
+        if (!verb.equalsIgnoreCase(MissionQuitCommand.QUIT.value()))
+        {
+            return false;
+        }
+        
+        player.sendChatMessage( "Quitting mission" );
+        iWantToQuit = true;
+        return true;
+    }
+
+    @Override
+    public boolean parseParameters(Object params)
+    {
+    	if (params == null || !(params instanceof MissionQuitCommands))
+    		return false;
+    	
+    	MissionQuitCommands cparams = (MissionQuitCommands)params;
+    	setUpAllowAndDenyLists(cparams.getModifierList());
+    	return true;
+    }
+
+
+    // ------------- ICommandHandler methods -----------
+    @Override
+    public void install(MissionInit missionInit)
+    {
+    }
+
+    @Override
+    public void deinstall(MissionInit missionInit)
+    {
+    }
+
+    @Override
+    public boolean isOverriding()
+    {
+        return this.isOverriding;
+    }
+
+    @Override
+    public void setOverriding(boolean b)
+    {
+        this.isOverriding = b;
+    }
+
+    
+    // ------------- IWantToQuit methods -----------
+    @Override
+	public boolean doIWantToQuit(MissionInit missionInit) {
+		return iWantToQuit;
+	}
+
+	@Override
+	public void prepare(MissionInit missionInit) {
+		iWantToQuit = false;
+	}
+
+	@Override
+	public void cleanup() {
+		
+	}
+
+	@Override
+	public String getOutcome() {
+		return "Quit from quit command";
+	}
+}

--- a/Schemas/Mission.xsd
+++ b/Schemas/Mission.xsd
@@ -349,7 +349,8 @@
             <xs:element ref="InventoryCommands" minOccurs="0"/>
             <xs:element ref="ChatCommands" minOccurs="0"/>
             <xs:element ref="SimpleCraftCommands" minOccurs="0"/>
-            <!-- When adding a new command handler, make sure to update MissionSpec::getListOfCommandHandlers and MissionSpec::getAllowedCommands -->
+            <xs:element ref="MissionQuitCommands" minOccurs="0"/>
+            <!-- When adding a new command handler, make sure to update MissionSpec::getListOfCommandHandlers and MissionSpec::getAllowedCommands --> 
 
             <xs:element ref="AgentQuitFromTimeUp" minOccurs="0" />
             <xs:element ref="AgentQuitFromReachingPosition" minOccurs="0" />

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -901,8 +901,21 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="MissionQuitCommand">
+    <xs:annotation>
+      <xs:documentation>
+        A command for ending the mission, example:
+      
+        "{{{quit}}}" - terminates the current mission.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="quit" />
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="Command">
-    <xs:union memberTypes="ContinuousMovementCommand AbsoluteMovementCommand DiscreteMovementCommand InventoryCommand ChatCommand SimpleCraftCommand"/>
+    <xs:union memberTypes="ContinuousMovementCommand AbsoluteMovementCommand DiscreteMovementCommand InventoryCommand ChatCommand SimpleCraftCommand MissionQuitCommand"/>
   </xs:simpleType>
 
   <xs:simpleType name="CommandList">
@@ -1074,6 +1087,29 @@
               <xs:restriction base="CommandListModifier">
                 <xs:choice maxOccurs="unbounded">
                   <xs:element name="command" type="ChatCommand" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:choice>
+              </xs:restriction>
+            </xs:complexContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="MissionQuitCommands">
+    <xs:annotation>
+      <xs:documentation>
+        When present, the Mod will accept a command that quits the mission.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="ModifierList" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:complexContent>
+              <xs:restriction base="CommandListModifier">
+                <xs:choice maxOccurs="unbounded">
+                  <xs:element name="command" type="MissionQuitCommand" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:choice>
               </xs:restriction>
             </xs:complexContent>


### PR DESCRIPTION
I implemented a solution to Issue #170, it allows the use of an AgentHandler, MissionQuitCommands, which responds to the 'quit' command by ending the mission.

It does so by implementing IWantToQuit and by appropriately returning true to doIWantToQuit() when a 'quit' message is received.
It receives messages by *also* implementing ICommandHandler. 

This forced me to do a change which you might not agree with. In MissionBehaviour.java, handlers are added to their appropriate producers by checking which interface they implement. This assumes that a single handler only implements one unique such interface. 
In this case since we want both a command handler and a quit producer, it is much more convenient that a single class implements both, but this requires to change MissionBehaviour::addHandler so that a single handler can be added to many producers, as long as they implement their respective interface.

An alternate solution, which I haven't tried, would be to necessitate two handlers, one message AgentHandler and one server ServerHandler that (somehow) communicates with the message receiver to decide when to quit. Since this seemed more complicated I didn't implement it.

Maybe there would be a simpler way that does not require a change to MissionBehaviour, but I am not familiar enough with the codebase that it appeared to me. I will be happy to try a different solution if needed.