### PR TITLE
Extended tabular_q_learning.py to request frames too

### DIFF
--- a/Malmo/samples/Python_examples/tabular_q_learning.py
+++ b/Malmo/samples/Python_examples/tabular_q_learning.py
@@ -26,11 +26,16 @@
 import MalmoPython
 import json
 import logging
+import math
 import os
 import random
 import sys
 import time
 import Tkinter as tk
+
+save_images = False
+if save_images:        
+    from PIL import Image
 
 class TabQAgent:
     """Tabular Q-learning agent for discrete state/action spaces."""
@@ -53,6 +58,8 @@ class TabQAgent:
         self.q_table = {}
         self.canvas = canvas
         self.root = root
+        
+        self.rep = 0
 
     def loadModel(self, model_file):
         """load q table from model_file"""
@@ -118,6 +125,7 @@ class TabQAgent:
 
         total_reward = 0
         current_r = 0
+        tol = 0.01
         
         self.prev_s = None
         self.prev_a = None
@@ -126,20 +134,37 @@ class TabQAgent:
         world_state = agent_host.peekWorldState()
         while world_state.is_mission_running and all(e.text=='{}' for e in world_state.observations):
             world_state = agent_host.peekWorldState()
+        # wait for a frame to arrive after that
+        num_frames_seen = world_state.number_of_video_frames_since_last_state
+        while world_state.is_mission_running and world_state.number_of_video_frames_since_last_state == num_frames_seen:
+            world_state = agent_host.peekWorldState()
         world_state = agent_host.getWorldState()
         for err in world_state.errors:
             print err
-        
+
         if not world_state.is_mission_running:
             return 0 # mission already ended
             
+        assert len(world_state.video_frames) > 0, 'No video frames!?'
+        
         obs = json.loads( world_state.observations[-1].text )
-        prev_x = int(obs[u'XPos'])
-        prev_z = int(obs[u'ZPos'])
+        prev_x = obs[u'XPos']
+        prev_z = obs[u'ZPos']
         print 'Initial position:',prev_x,',',prev_z
+        
+        if save_images:
+            # save the frame, for debugging
+            frame = world_state.video_frames[-1]
+            image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+            iFrame = 0
+            self.rep = self.rep + 1
+            image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(iFrame).zfill(4) + '.png' )
             
         # take first action
         total_reward += self.act(world_state,agent_host,current_r)
+        
+        require_move = True
+        check_expected_position = True
         
         # main loop:
         while world_state.is_mission_running:
@@ -153,29 +178,63 @@ class TabQAgent:
                     break
                 if len(world_state.rewards) > 0 and not all(e.text=='{}' for e in world_state.observations):
                     obs = json.loads( world_state.observations[-1].text )
-                    curr_x = int(obs[u'XPos'])
-                    curr_z = int(obs[u'ZPos'])
-                    if not curr_x == prev_x or not curr_z == prev_z:
+                    curr_x = obs[u'XPos']
+                    curr_z = obs[u'ZPos']
+                    if require_move:
+                        if math.hypot( curr_x - prev_x, curr_z - prev_z ) > tol:
+                            print 'received.'
+                            break
+                    else:
                         print 'received.'
                         break
+            # wait for a frame to arrive after that
+            num_frames_seen = world_state.number_of_video_frames_since_last_state
+            while world_state.is_mission_running and world_state.number_of_video_frames_since_last_state == num_frames_seen:
+                world_state = agent_host.peekWorldState()
+                
+            num_frames_before_get = len(world_state.video_frames)
             
             world_state = agent_host.getWorldState()
             for err in world_state.errors:
                 print err
             current_r = sum(r.getValue() for r in world_state.rewards)
+
+            if save_images:
+                # save the frame, for debugging
+                if world_state.is_mission_running:
+                    assert len(world_state.video_frames) > 0, 'No video frames!?'
+                    frame = world_state.video_frames[-1]
+                    image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+                    iFrame = iFrame + 1
+                    image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(iFrame).zfill(4) + '_after_' + self.actions[self.prev_a] + '.png' )
                 
             if world_state.is_mission_running:
+                assert len(world_state.video_frames) > 0, 'No video frames!?'
+                num_frames_after_get = len(world_state.video_frames)
+                assert num_frames_after_get >= num_frames_before_get, 'Fewer frames after getWorldState!?'
+                frame = world_state.video_frames[-1]
                 obs = json.loads( world_state.observations[-1].text )
-                curr_x = int(obs[u'XPos'])
-                curr_z = int(obs[u'ZPos'])
-                print 'New position:',curr_x,',',curr_z,'after action:',self.actions[self.prev_a], #NSWE
-                expected_x = prev_x + [0,0,-1,1][self.prev_a]
-                expected_z = prev_z + [-1,1,0,0][self.prev_a]
-                if not curr_x == expected_x or not curr_z == expected_z:
-                    print ' - ERROR DETECTED! Expected:',expected_x,',',expected_z
-                    raw_input("Press Enter to continue...")
+                curr_x = obs[u'XPos']
+                curr_z = obs[u'ZPos']
+                print 'New position from observation:',curr_x,',',curr_z,'after action:',self.actions[self.prev_a], #NSWE
+                if check_expected_position:
+                    expected_x = prev_x + [0,0,-1,1][self.prev_a]
+                    expected_z = prev_z + [-1,1,0,0][self.prev_a]
+                    if math.hypot( curr_x - expected_x, curr_z - expected_z ) > tol:
+                        print ' - ERROR DETECTED! Expected:',expected_x,',',expected_z
+                        raw_input("Press Enter to continue...")
+                    else:
+                        print 'as expected.'
+                    curr_x_from_render = frame.xPos
+                    curr_z_from_render = frame.zPos
+                    print 'New position from render:',curr_x_from_render,',',curr_z_from_render,'after action:',self.actions[self.prev_a], #NSWE
+                    if math.hypot( curr_x_from_render - expected_x, curr_z_from_render - expected_z ) > tol:
+                        print ' - ERROR DETECTED! Expected:',expected_x,',',expected_z
+                        raw_input("Press Enter to continue...")
+                    else:
+                        print 'as expected.'
                 else:
-                    print 'as expected.'
+                    print
                 prev_x = curr_x
                 prev_z = curr_z
                 # act
@@ -276,7 +335,6 @@ else:
 for imap in xrange(num_maps):
 
     # -- set up the agent -- #
-    #actionSet = ["movenorth 1", "movesouth 1", "movewest 1", "moveeast 1", "turn 1", "turn -1"]
     actionSet = ["movenorth 1", "movesouth 1", "movewest 1", "moveeast 1"]
 
     agent = TabQAgent(


### PR DESCRIPTION
Demonstrates how rendered frames can be robustly obtained from discrete actions.

(The code to achieve this is more complex than I'd like, so we still have work to do.)

Closes #231.