### PR TITLE
Sending errors to the err stream instead of out stream in the Java example

### DIFF
--- a/Malmo/samples/Java_examples/JavaExamples_run_mission.java
+++ b/Malmo/samples/Java_examples/JavaExamples_run_mission.java
@@ -47,7 +47,7 @@ public class JavaExamples_run_mission
         catch( Exception e )
         {
             System.err.println( "ERROR: " + e.getMessage() );
-            System.out.println( agent_host.getUsage() );
+            System.err.println( agent_host.getUsage() );
             System.exit(1);
         }
         if( agent_host.receivedArgument("help") )

--- a/Malmo/samples/Java_examples/JavaExamples_run_mission.java
+++ b/Malmo/samples/Java_examples/JavaExamples_run_mission.java
@@ -46,7 +46,7 @@ public class JavaExamples_run_mission
         }
         catch( Exception e )
         {
-            System.out.println( "ERROR: " + e.getMessage() );
+            System.err.println( "ERROR: " + e.getMessage() );
             System.out.println( agent_host.getUsage() );
             System.exit(1);
         }
@@ -71,7 +71,7 @@ public class JavaExamples_run_mission
             agent_host.startMission( my_mission, my_mission_record );
         }
         catch (Exception e) {
-            System.out.println( "Error starting mission: " + e.getMessage() );
+            System.err.println( "Error starting mission: " + e.getMessage() );
             System.exit(1);
         }
 
@@ -83,12 +83,12 @@ public class JavaExamples_run_mission
             try {
                 Thread.sleep(100);
             } catch(InterruptedException ex) {
-                System.out.println( "User interrupted while waiting for mission to start." );
+                System.err.println( "User interrupted while waiting for mission to start." );
                 return;
             }
             world_state = agent_host.getWorldState();
             for( int i = 0; i < world_state.getErrors().size(); i++ )
-                System.out.println( "Error: " + world_state.getErrors().get(i).getText() );
+                System.err.println( "Error: " + world_state.getErrors().get(i).getText() );
         } while( !world_state.getIsMissionRunning() );
         System.out.println( "" );
 
@@ -99,7 +99,7 @@ public class JavaExamples_run_mission
             try {
                 Thread.sleep(500);
             } catch(InterruptedException ex) {
-                System.out.println( "User interrupted while mission was running." );
+                System.err.println( "User interrupted while mission was running." );
                 return;
             }
             world_state = agent_host.getWorldState();
@@ -113,7 +113,7 @@ public class JavaExamples_run_mission
             }
             for( int i = 0; i < world_state.getErrors().size(); i++ ) {
                 TimestampedString error = world_state.getErrors().get(i);
-                System.out.println( "Error: " + error.getText() );
+                System.err.println( "Error: " + error.getText() );
             }
         } while( world_state.getIsMissionRunning() );
 


### PR DESCRIPTION
As the title states, error messages in the Java example are now printed to the System.err stream instead of the System.out stream.