### PR TITLE
Multiagent missions with a single set of credentials, on the same machine.

### DIFF
--- a/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
@@ -902,6 +902,7 @@ public class ClientStateMachine extends StateMachine implements IMalmoMessageLis
                 // Do we need to open to LAN?
                 if (Minecraft.getMinecraft().isSingleplayer() && !Minecraft.getMinecraft().getIntegratedServer().getPublic())
                 {
+                    Minecraft.getMinecraft().getIntegratedServer().setOnlineMode(false);
                     String portstr = Minecraft.getMinecraft().getIntegratedServer().shareToLAN(GameType.SURVIVAL, false); // Set to true to stop spam kicks?
                     ClientStateMachine.this.integratedServerPort = Integer.valueOf(portstr);
                 }
@@ -919,7 +920,27 @@ public class ClientStateMachine extends StateMachine implements IMalmoMessageLis
                 System.out.println("We should be joining " + targetIP);
                 // Always connect, even if we're already on the same server -
                 // otherwise things get out of step.
+try {
+    net.minecraft.client.multiplayer.ServerData serverData = new net.minecraft.client.multiplayer.ServerData("Command Line", address+":"+port);
+
+    net.minecraftforge.fml.client.FMLClientHandler.instance().showGuiScreen(new net.minecraft.client.multiplayer.GuiConnecting(new net.minecraft.client.gui.GuiMainMenu(), Minecraft.getMinecraft(), serverData));
+
+
                 net.minecraftforge.fml.client.FMLClientHandler.instance().connectToServerAtStartup(address, port);
+
+//net.minecraftforge.fml.client.FMLClientHandler.instance().connectToServer(new GuiMainMenu(), new net.minecraft.client.multiplayer.ServerData("Command Line", address+":"+port));
+//
+//UserAuthentication uauth = ((com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService)service).getAuthenticationService().createUserAuthentication(Agent.MINECRAFT);
+//        if (!(uauth instanceof com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication))
+//            return null;
+//
+//        com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService auth= (com.mojang.authlib.yggdrasil.YggdrasilUserAuthentication)uauth;
+//
+//Minecraft.getMinecraft().getSessionService().joinServer(Minecraft.getMinecraft().getSession().getProfile(), auth.getAuthenticatedToken(), serverid);
+//
+//System.err.println("TNARIK - after connectToServerAtStartup" + targetIP);
+} catch(Exception e) { e.printStackTrace(); throw(e); }
+
             }
         }
 

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Utils/AuthenticationHelper.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Utils/AuthenticationHelper.java
@@ -209,7 +209,7 @@ public class AuthenticationHelper
             String s = portToUserMappings[i];
             if (s.endsWith(user))
             {
-                String strport = s.substring(0, s.length() - (user.length() + 1));	// +1 for the colon - portnumber:username
+                String strport = s.substring(0, s.length() - (user.length() + 1));  // +1 for the colon - portnumber:username
                 Integer port = null;
                 try
                 {
@@ -283,8 +283,31 @@ public class AuthenticationHelper
         auth.setPassword(AuthenticationHelper.password);
         try
         {
+//auth.logIn();
+
             if (!AuthenticationHelper.username.equals(UNAUTH) && !AuthenticationHelper.password.isEmpty())
             {
+//
+//        Configuration config = MalmoMod.instance.getModPermanentConfigFile();
+//        String[] portToPlayernameMappings = config.getStringList(PROP_PORT_TO_PLAYERNAME_MAPPINGS, MalmoMod.AUTHENTICATION_CONFIGS, new String[0], I18n.format("auth."+PROP_PORT_TO_PLAYERNAME_MAPPINGS, new Object[0]));
+//System.err.println("TNARIK - set playername");
+//        String playername = getPlayernameForPort(AddressHelper.getMissionControlPort(), portToPlayernameMappings);
+//        if ( playername == null )
+//            playername = auth.getSelectedProfile().getName();
+//// try to change gameprofile before login
+//    com.mojang.authlib.GameProfile gameProfileOld = Minecraft.getMinecraft().getSession().getProfile();
+//System.err.println("TNARIK - get a old gameprofile - pre login "+gameProfileOld);
+//try{
+//    com.mojang.authlib.GameProfile aa = new com.mojang.authlib.GameProfile(gameProfileOld.getId(), playername);
+//    auth.selectGameProfile(aa);
+//System.err.println("TNARIK - get a refreshed gameprofile - pre login "+aa);
+//// let's see
+//}catch(Exception e) {
+//    e.printStackTrace();
+//}
+
+
+
                 auth.logIn();
                 if (forceSessionUpdate(auth))
                     return true;
@@ -298,15 +321,43 @@ public class AuthenticationHelper
 
     private static boolean forceSessionUpdate(YggdrasilUserAuthentication auth)
     {
+
+
+System.err.println("TNARIK - forcing session update");
+System.err.println("TNARIK - forcing session update with auth "+auth);
 //        String playername = auth.getSelectedProfile().getName()+"_"+String.valueOf(AddressHelper.getMissionControlPort());
         Configuration config = MalmoMod.instance.getModPermanentConfigFile();
         String[] portToPlayernameMappings = config.getStringList(PROP_PORT_TO_PLAYERNAME_MAPPINGS, MalmoMod.AUTHENTICATION_CONFIGS, new String[0], I18n.format("auth."+PROP_PORT_TO_PLAYERNAME_MAPPINGS, new Object[0]));
+System.err.println("TNARIK - set playername");
         String playername = getPlayernameForPort(AddressHelper.getMissionControlPort(), portToPlayernameMappings);
         if ( playername == null )
             playername = auth.getSelectedProfile().getName();
+System.err.println("TNARIK - get session");
+Session asession = Minecraft.getMinecraft().getSession();
+if (!asession.hasCachedProperties()) {
+    System.err.println("TNARIK - current session has no cached properties");
+}
 
+
+// atempt with same session
+    com.mojang.authlib.GameProfile gameProfileOld = Minecraft.getMinecraft().getSession().getProfile();
+System.err.println("TNARIK - get a old gameprofile "+gameProfileOld);
+try{
+    com.mojang.authlib.GameProfile aa = new com.mojang.authlib.GameProfile(gameProfileOld.getId(), playername);
+    auth.selectGameProfile(aa);
+System.err.println("TNARIK - get a refreshed gameprofile "+aa);
+// let's see
+}catch(Exception e) {
+    e.printStackTrace();
+}
+
+
+System.err.println("TNARIK - no cached properties");
+System.err.println("TNARIK - got session "+asession);
+System.err.println("TNARIK - create session");
         // Create new session object:
         Session newSession = new Session(playername, auth.getSelectedProfile().getId().toString(), auth.getAuthenticatedToken(), auth.getUserType().getName());
+System.err.println("TNARIK - a new session is born");
         // Are we in the dev environment or deployed?
         boolean devEnv = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment");
         // We need to know, because the member name will either be obfuscated or not.
@@ -321,9 +372,12 @@ public class AuthenticationHelper
             // It seems setting the session doesn't apply to the game profile correctly
             // Using code from (net.minecraft.client.Minecraft@launchIntegratedServer), we force a reload (using same fix as for Fixes MC-52974.)
             com.mojang.authlib.GameProfile gameProfile = Minecraft.getMinecraft().getSession().getProfile();
+System.err.println("TNARIK - get a pre new gameprofile "+gameProfile);
             if (!Minecraft.getMinecraft().getSession().hasCachedProperties())
             {
+System.err.println("TNARIK - new session has no cached properties "+session);
                 gameProfile = Minecraft.getMinecraft().getSessionService().fillProfileProperties(gameProfile, true);
+System.err.println("TNARIK - get a new gameprofile "+gameProfile);
                 Minecraft.getMinecraft().getSession().setProperties(gameProfile.getProperties());
             }
             return true;

--- a/Minecraft/src/main/resources/assets/MalmoMod/lang/en_US.lang
+++ b/Minecraft/src/main/resources/assets/MalmoMod/lang/en_US.lang
@@ -5,6 +5,7 @@ key.categories.malmo=Malmo
 key.toggleMalmo=Toggle AI/human control
 key.handyTestHook=Test hook (dump recipe list)
 
-auth.usernames=List of authenticated usernames
+auth.ports=List of configured ports
 auth.portToUserMappings=Map ports to usernames in format <port>:<username>
 auth.usernameToPasswordMappings=Map usernames to passwords in format <username>:<password>
+auth.portToPlayernameMappings=Map ports to playernames in format <port>:<playername>


### PR DESCRIPTION
Current implementation  allows multiagent missions with a single set of credentials, on the same host. There seems to be some game profile or token linked to the specific host (will try to clarify this).

This implementation supports:
- configuration of the playernames in the authorization configuration screen for the mod
- automatic use of the game profile name if it is not provided (this would work for one of the entries).

Known issues:
- Multiagent from multiple hosts fails. I think it is due to the way Malmo does authentication, but it might also be an issue with my test setup (I am using docker containers).
