### PR TITLE
Jumpuse

### DIFF
--- a/Malmo/samples/Python_examples/team_reward_test.py
+++ b/Malmo/samples/Python_examples/team_reward_test.py
@@ -19,8 +19,8 @@
 
 # A sample that demonstrates the use of reward sharing.
 # Two agents:
-#   Simeon the Stylite
-#   Fred Dibnah
+#   Simeon the Stylite (https://en.wikipedia.org/wiki/Simeon_Stylites)
+#   Fred Dibnah (https://en.wikipedia.org/wiki/Fred_Dibnah)
 
 # Goal: Simeon must safely walk from his starting point to a goal square...
 # but his starting point is at the top of a pole, 21 blocks above ground level, and the goal
@@ -113,7 +113,7 @@ xml = '''<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
       <Placement x="-22.5" y="227.0" z="-1.5" pitch="90" yaw="180"/>
     </AgentStart>
     <AgentHandlers>
-      <DiscreteMovementCommands autoJump="true" autoFall="false"/>
+      <DiscreteMovementCommands autoJump="true" autoFall="true"/>
       <ObservationFromChat/>
       <RewardForSendingCommand reward="1" distribution="SimeonTheStylite:1"/>
     </AgentHandlers>
@@ -142,7 +142,7 @@ for x in xrange(20):
         instructions.append("strafe 1")
     instructions.append("move -1")
     for y in xrange(x+1):
-        instructions.append("jump-use")
+        instructions.append("jumpuse")
     for y in xrange(x+1):
         instructions.append("strafe -1")
 
@@ -207,12 +207,7 @@ while agent_host_simeon.peekWorldState().is_mission_running or agent_host_fred.p
         for command in chat:
             parts = command.split("> ")
             if len(parts) > 1:
-                if parts[1] == "jump-use":
-                    agent_host_fred.sendCommand("jump")
-                    agent_host_fred.sendCommand("jump")
-                    agent_host_fred.sendCommand("use")
-                else:
-                    agent_host_fred.sendCommand(str(parts[1]))
+                agent_host_fred.sendCommand(str(parts[1]))
 
 # check the rewards obtained
 world_state1 = agent_host_simeon.getWorldState()

--- a/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/ObservationFromRayImplementation.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/MissionHandlers/ObservationFromRayImplementation.java
@@ -20,10 +20,7 @@
 package com.microsoft.Malmo.MissionHandlers;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import net.minecraft.block.properties.IProperty;
 import net.minecraft.block.state.IBlockState;

--- a/Schemas/MissionHandlers.xsd
+++ b/Schemas/MissionHandlers.xsd
@@ -1003,6 +1003,8 @@
         "{{{attack 1}}}" - destroy the block that has focus.
         
         "{{{use 1}}}" - place the held block item on the block face that has focus.
+        
+        "{{{jumpuse}}}" - simultaneously jump and place the held block on the block face that has focus.
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
@@ -1023,6 +1025,7 @@
       <xs:enumeration value="look" />
       <xs:enumeration value="attack" />
       <xs:enumeration value="use" />
+      <xs:enumeration value="jumpuse" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 0.19.0
 -------------------
+New: Discrete jumpuse action (great for nerd poling). (#400)
 New: Team rewards. (#279)
 New: Discrete strafe and jump actions, autojump and autofall. (#352, #321)
 New: Simple animation decorator. (#389)


### PR DESCRIPTION
Adds a "jump-use" command, which allows simultaneous(ish) jumping and block placing. This is important for situations where the agent needs to "nerd pole" - ie place a block beneath its own feet.

This closes #400.