### PR TITLE
Fix cmake for installed Cpp_Examples

### DIFF
--- a/Malmo/samples/Cpp_examples/CMakeLists.txt.in
+++ b/Malmo/samples/Cpp_examples/CMakeLists.txt.in
@@ -1,15 +1,15 @@
 # ------------------------------------------------------------------------------------------------
 # Copyright (c) 2016 Microsoft Corporation
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
 # associated documentation files (the "Software"), to deal in the Software without restriction,
 # including without limitation the rights to use, copy, modify, merge, publish, distribute,
 # sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all copies or
 # substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
 # NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 # NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
@@ -39,6 +39,11 @@ endif()
 
 find_package( Xsd REQUIRED )
 
+if(NOT WIN32)
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  find_package( Threads REQUIRED )
+endif()
+
 find_library( Malmo_LIBRARIES Malmo ${CMAKE_SOURCE_DIR}/lib )
 
 # ------------------- Settings --------------------------------------
@@ -51,19 +56,25 @@ if (CMAKE_VERSION VERSION_LESS "3.1")
 else ()
   set (CMAKE_CXX_STANDARD 11)
 endif ()
-  
+
 # ------------ Build the executable ---------------------------------
+
+set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations" ) # get a lot of warnings from Boost about auto_ptr
 
 add_executable( run_mission ${SOURCES} )
 
-include_directories( 
+include_directories(
   ${CMAKE_SOURCE_DIR}/include
   ${Boost_INCLUDE_DIR}
   ${XSD_INCLUDE_DIRS}
 )
 
-target_link_libraries( run_mission 
+target_link_libraries( run_mission
   ${Malmo_LIBRARIES}
   ${Boost_LIBRARIES}
-  ${XSD_LIBRARIES} 
+  ${XSD_LIBRARIES}
 )
+
+if( NOT WIN32 )
+  target_link_libraries(run_mission ${CMAKE_THREAD_LIBS_INIT} )
+endif()

--- a/cmake/FindXsd.cmake
+++ b/cmake/FindXsd.cmake
@@ -28,7 +28,7 @@ set(XSD_NAMES_DEBUG xerces-cD xerces-c_3D)
 # Malmo-specific thing: on some platforms we need to manually install CodeSynthesis XSD and so the standard
 # exectable name is 'xsd' instead of 'xsdcxx'. On others, 'xsd' matches an executable in Mono
 # and so we have to avoid that.
-if( ( ${SYSTEM_NAME} MATCHES "^Linux-Ubuntu-14.04.*$" ) OR ( ${SYSTEM_NAME} MATCHES "^Linux-Debian-7\\..*$" ) OR ( ${SYSTEM_NAME} STREQUAL "Mac-64bit" ) )
+if( ( "${SYSTEM_NAME}" MATCHES "^Linux-Ubuntu-14.04.*$" ) OR ( "${SYSTEM_NAME}" MATCHES "^Linux-Debian-7\\..*$" ) OR ( "${SYSTEM_NAME}" STREQUAL "Mac-64bit" ) )
   set( EXTRA_XSD_EXECUTABLE_NAMES "xsd" )
 endif()
 
@@ -45,7 +45,7 @@ if(NOT XSD_LIBRARY)
   else()
     set( _XSD_LIB_DIR lib )
   endif()
-  
+
   foreach(search ${_XSD_SEARCHES})
     find_library(XSD_LIBRARY_RELEASE NAMES ${XSD_NAMES} ${${search}} PATH_SUFFIXES ${_XSD_LIB_DIR}/vc-12.0)
     find_library(XSD_LIBRARY_DEBUG NAMES ${XSD_NAMES_DEBUG} ${${search}} PATH_SUFFIXES ${_XSD_LIB_DIR}/vc-12.0)
@@ -62,7 +62,7 @@ MARK_AS_ADVANCED(
   XSD_LIBRARY
   XSD_INCLUDE_DIR
   XSD_EXECUTABLE
-) 
+)
 
 # if the include and the program are found then we have it
 IF(XSD_INCLUDE_DIR)
@@ -94,11 +94,10 @@ IF(XSD_INCLUDE_DIR)
 		set_target_properties(XSD::XSD PROPERTIES
 			IMPORTED_LOCATION_DEBUG "${XSD_LIBRARY_DEBUG}")
 		endif()
-		
+
 		if(NOT XSD_LIBRARY_RELEASE AND NOT XSD_LIBRARY_DEBUG)
         set_property(TARGET XSD::XSD APPEND PROPERTY
           IMPORTED_LOCATION "${XSD_LIBRARY}")
       endif()
 	ENDIF()
 ENDIF(XSD_INCLUDE_DIR)
-


### PR DESCRIPTION
For the installed Cpp_Examples, SYSTEM_NAME is not defined. Hence need to change FindXsd to allow empty string.
And need to get pthread for linking.