### PR TITLE
Updated Mac instructions for OSX 10.12, improved clarity

### DIFF
--- a/doc/build_macosx.md
+++ b/doc/build_macosx.md
@@ -1,7 +1,7 @@
 
 ## Build on MacOSX ##
 
-These instructions were tested on MacOSX 10.12 (El Capitan).
+These instructions were tested on MacOSX 10.12 (Sierra).
 
 1. Install Homebrew: https://coolestguidesontheplanet.com/installing-homebrew-on-os-x-el-capitan-10-11-package-manager-for-unix-apps/
 

--- a/doc/build_macosx.md
+++ b/doc/build_macosx.md
@@ -13,6 +13,7 @@ These instructions were tested on MacOSX 10.12 (Sierra).
   brew install boost --with-python
   brew install ffmpeg swig boost-python xerces-c doxygen git cmake
   brew cask install java
+  brew install wget --with-libressl
   brew install cmake
   brew install doxygen
   brew install swig

--- a/doc/build_macosx.md
+++ b/doc/build_macosx.md
@@ -22,6 +22,7 @@ These instructions were tested on MacOSX 10.12 (El Capitan).
   brew link --overwrite xsd
   ```
 Installing some of these dependencies may create linking errors. Follow the instructions suggested by the error messages.
+You may also need to follow the first three steps found here to update Java 3D to version 1.5: https://blogs.oracle.com/mart/entry/installing_java3d_1_5_on
 
 3. Clone and build Project Malmo:
     1. `git clone https://github.com/Microsoft/malmo.git ~/MalmoPlatform`  

--- a/doc/build_macosx.md
+++ b/doc/build_macosx.md
@@ -1,9 +1,9 @@
 
 ## Build on MacOSX ##
 
-These instructions were tested on MacOSX 10.11.1 (El Capitan).
+These instructions were tested on MacOSX 10.12 (El Capitan).
 
-1. Install Homebrew: http://www.howtogeek.com/211541/homebrew-for-os-x-easily-installs-desktop-apps-and-terminal-utilities/
+1. Install Homebrew: https://coolestguidesontheplanet.com/installing-homebrew-on-os-x-el-capitan-10-11-package-manager-for-unix-apps/
 
 2. Install dependencies:
 
@@ -12,16 +12,20 @@ These instructions were tested on MacOSX 10.11.1 (El Capitan).
   brew upgrade
   brew install boost --with-python
   brew install ffmpeg swig boost-python xerces-c doxygen git cmake
-  sudo brew cask install java
+  brew cask install java
+  brew install cmake
+  brew install doxygen
+  brew install swig
   brew install xsd
   brew unlink xsd
   brew install mono
   brew link --overwrite xsd
   ```
+Installing some of these dependencies may create linking errors. Follow the instructions suggested by the error messages.
 
 3. Clone and build Project Malmo:
     1. `git clone https://github.com/Microsoft/malmo.git ~/MalmoPlatform`  
-    2. `wget https://raw.githubusercontent.com/bitfehler/xs3p/1b71310dd1e8b9e4087cf6120856c5f701bd336b/xs3p.xsl -P ~/MalmoPlatform/Schemas`
+    2. `wget --no-check-certificate https://raw.githubusercontent.com/bitfehler/xs3p/1b71310dd1e8b9e4087cf6120856c5f701bd336b/xs3p.xsl -P ~/MalmoPlatform/Schemas`
     3. Add `export MALMO_XSD_PATH=~/MalmoPlatform/Schemas` to your `~/.bashrc` and do `source ~/.bashrc`
     3. `cd MalmoPlatform`
     4. `mkdir build`

--- a/doc/build_macosx.md
+++ b/doc/build_macosx.md
@@ -32,8 +32,10 @@ You may also need to follow the first three steps found here to update Java 3D t
     4. `mkdir build`
     5. `cd build`
     6. `cmake ..`
-    7. `make install`
-    8. Then you can run the samples that are installed ready-to-run in e.g. `install/Python_Examples`
+    7. `make install` (this could take awhile)
+    8. `cd ../Minecract`
+    9. `./launchClient.sh`
+    8. Then you can run the samples from another terminal window that are installed ready-to-run in e.g. `install/Python_Examples`
 
 4. Run the tests:
     1. `cd MalmoPlatform/build`

--- a/doc/install_macosx.md
+++ b/doc/install_macosx.md
@@ -1,11 +1,11 @@
 ## Installing dependencies for MacOSX ##
 
-1. Install Homebrew: http://www.howtogeek.com/211541/homebrew-for-os-x-easily-installs-desktop-apps-and-terminal-utilities/
+1. Install Homebrew: https://coolestguidesontheplanet.com/installing-homebrew-on-os-x-el-capitan-10-11-package-manager-for-unix-apps/
     
 2. Install dependencies:
     1. `brew install boost --with-python`
     2. `brew install boost-python ffmpeg xerces-c mono`
-    3. `sudo brew cask install java`
+    3. `brew cask install java`
 
 3. If you have not already done so, unzip the Malmo zip to some location (e.g. your home folder).
 4. Add `export MALMO_XSD_PATH=~/MalmoPlatform/Schemas` (or your Schemas location) to your `~/.bashrc` and do `source ~/.bashrc`

--- a/doc/install_macosx.md
+++ b/doc/install_macosx.md
@@ -1,3 +1,5 @@
+These instructions seem to cause a lot of errors with many users, especially on OSX 10.12. It is recomended that you [build Malmo yourself](build_macosx.md). 
+
 ## Installing dependencies for MacOSX ##
 
 1. Install Homebrew: https://coolestguidesontheplanet.com/installing-homebrew-on-os-x-el-capitan-10-11-package-manager-for-unix-apps/
@@ -13,7 +15,7 @@
 
 ## Notes: ##
 
-These instructions were tested on MacOSX 10.12. 
+These instructions were tested on MacOSX 10.11. 
 
 On MacOSX we currently only support the system python, so please use `/usr/bin/python` for running agents, if it is not already the default. 
 

--- a/doc/install_macosx.md
+++ b/doc/install_macosx.md
@@ -13,7 +13,7 @@
 
 ## Notes: ##
 
-These instructions were tested on MacOSX 10.11 (El Capitan). 
+These instructions were tested on MacOSX 10.12. 
 
 On MacOSX we currently only support the system python, so please use `/usr/bin/python` for running agents, if it is not already the default. 
 


### PR DESCRIPTION
The instructions for installing Malmo on a Mac flat out didn't work for many people, even those using older versions of OSX (10.10 or 10.11). These updated instructions properly inform users how to build Malmo themselves on a Mac running 10.12 with greater clarity.