### PR TITLE
Fixes for save_images in python examples for python3. Fixes #631

### DIFF
--- a/Malmo/samples/Python_examples/robust_frames.py
+++ b/Malmo/samples/Python_examples/robust_frames.py
@@ -82,7 +82,7 @@ class RandomAgent(object):
             if save_images:
                 # save the frame, for debugging
                 frame = world_state.video_frames[-1]
-                image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+                image = Image.frombytes('RGB', (frame.width, frame.height), bytes(frame.pixels) )
                 self.iFrame = 0
                 self.rep = self.rep + 1
                 image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(self.iFrame).zfill(4) + '.png' )
@@ -152,7 +152,7 @@ class RandomAgent(object):
             if world_state.is_mission_running:
                 assert len(world_state.video_frames) > 0, 'No video frames!?'
                 frame = world_state.video_frames[-1]
-                image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+                image = Image.frombytes('RGB', (frame.width, frame.height), bytes(frame.pixels) )
                 self.iFrame = self.iFrame + 1
                 image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(self.iFrame).zfill(4) + '.png' )
             

--- a/Malmo/samples/Python_examples/run_mission.py
+++ b/Malmo/samples/Python_examples/run_mission.py
@@ -89,5 +89,5 @@ while world_state.is_mission_running:
         print("Error:",error.text)
     for frame in world_state.video_frames:
         print("Frame:",frame.width,'x',frame.height,':',frame.channels,'channels')
-        #image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) ) # to convert to a PIL image
+        #image = Image.frombytes('RGB', (frame.width, frame.height), bytes(frame.pixels) ) # to convert to a PIL image
 print("Mission has stopped.")

--- a/Malmo/samples/Python_examples/tabular_q_learning.py
+++ b/Malmo/samples/Python_examples/tabular_q_learning.py
@@ -166,7 +166,7 @@ class TabQAgent(object):
         if save_images:
             # save the frame, for debugging
             frame = world_state.video_frames[-1]
-            image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+            image = Image.frombytes('RGB', (frame.width, frame.height), bytes(frame.pixels) )
             iFrame = 0
             self.rep = self.rep + 1
             image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(iFrame).zfill(4) + '.png' )
@@ -215,7 +215,7 @@ class TabQAgent(object):
                 if world_state.is_mission_running:
                     assert len(world_state.video_frames) > 0, 'No video frames!?'
                     frame = world_state.video_frames[-1]
-                    image = Image.frombytes('RGB', (frame.width, frame.height), str(frame.pixels) )
+                    image = Image.frombytes('RGB', (frame.width, frame.height), bytes(frame.pixels) )
                     iFrame = iFrame + 1
                     image.save( 'rep_' + str(self.rep).zfill(3) + '_saved_frame_' + str(iFrame).zfill(4) + '_after_' + self.actions[self.prev_a] + '.png' )
                 


### PR DESCRIPTION
This is a fix for #631 .
NB: I haven't tested if this breaks when used with python2, only tested with python3.