### PR TITLE
Fixing format error when running tutorial_6

### DIFF
--- a/Malmo/samples/Python_examples/tutorial_6.py
+++ b/Malmo/samples/Python_examples/tutorial_6.py
@@ -226,7 +226,7 @@ class TabQAgent(object):
                         continue
                     value = self.q_table[s][action]
                     color = 255 * ( value - min_value ) / ( max_value - min_value ) # map value to 0-255
-                    color = max( min( color, 255 ), 0 ) # ensure within [0,255]
+                    color = int(max( min( color, 255 ), 0 )) # ensure within [0,255]
                     color_string = '#%02x%02x%02x' % (255-color, color, 0)
                     self.canvas.create_oval( (x + action_positions[action][0] - action_radius ) *scale,
                                              (y + action_positions[action][1] - action_radius ) *scale,


### PR DESCRIPTION
I was getting the following error when running tutorial_6.py:

```
Traceback (most recent call last):
  File ".\tutorial_6.py", line 311, in <module>
    cumulative_reward = agent.run(agent_host)
  File ".\tutorial_6.py", line 162, in run
    total_reward += self.act(world_state, agent_host, current_r)
  File ".\tutorial_6.py", line 107, in act
    self.drawQ( curr_x = int(obs[u'XPos']), curr_y = int(obs[u'ZPos']) )
  File ".\tutorial_6.py", line 230, in drawQ
    color_string = '#%02x%02x%02x' % (255-color, color, 0)
TypeError: %x format: an integer is required, not float

```
Using the "int" function in line 229 solved the problem for me.
I hope this helps.