### PR TITLE
Sample_missions path wrong at tabular_q_learning.py

### DIFF
--- a/Malmo/samples/Python_examples/tabular_q_learning.py
+++ b/Malmo/samples/Python_examples/tabular_q_learning.py
@@ -312,7 +312,7 @@ try:
 except KeyError:
     print("MALMO_XSD_PATH not set? Check environment.")
     exit(1)
-mission_file = os.path.abspath(os.path.join(schema_dir, '..', 'sample_missions', 'cliff_walking_1.xml'))
+mission_file = os.path.abspath(os.path.join(schema_dir, '..', 'Sample_missions', 'cliff_walking_1.xml'))
 
 # add some args
 agent_host.addOptionalStringArgument('mission_file',


### PR DESCRIPTION
The Sample_missions path in tabular_q_learning.py starts with a lowercase 's' instead of Sample_missions.