### PR TITLE
#678 - Fixed FFPMEG file name in installation script

### DIFF
--- a/scripts/malmo_install.ps1
+++ b/scripts/malmo_install.ps1
@@ -14,6 +14,9 @@ if (-Not (Test-Path .\temp))
     mkdir temp
 }
 
+# Force PowerShell to use TLS 1.2 which is a requirement for some download locations
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 # Attempt to get version information from the Malmo properties file.
 # (This file was added in 0.34.0)
 try {

--- a/scripts/pslib/malmo_lib.psm1
+++ b/scripts/pslib/malmo_lib.psm1
@@ -109,8 +109,8 @@ function Install-Ffmpeg
     if ($env:path -notmatch "ffmpeg")
     {
         Display-Heading "Installing ffmpeg"
-        Download-File "http://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-latest-win64-static.7z" ($env:HOMEPATH + "\temp\ffmpeg.7z")
-        & 'C:\Program Files\7-Zip\7z.exe' x .\temp\ffmpeg.7z -oC:\ffmpeg | Out-Host
+        Download-File "http://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-latest-win64-static.zip" ($env:HOMEPATH + "\temp\ffmpeg.zip")
+        & 'C:\Program Files\7-Zip\7z.exe' x .\temp\ffmpeg.zip -oC:\ffmpeg | Out-Host
         if ($?)
         {
             cp -r C:\ffmpeg\ffmpeg-latest-win64-static\* C:\ffmpeg


### PR DESCRIPTION
Forced PowerShell to use TLS 1.2 to resolve Python download issues due to PowerShell defaulting to TLS 1.0