### PR TITLE
Statelock

### DIFF
--- a/Malmo/src/AgentHost.cpp
+++ b/Malmo/src/AgentHost.cpp
@@ -728,6 +728,44 @@ namespace malmo
         this->world_state.is_mission_running = false;
         closeServers();
         closeRecording();
+
+        // Ensure all TCP server ports are closed.
+
+        if (this->video_server) {
+            this->video_server->close();
+            this->video_server = 0;
+        }
+
+        if (this->depth_server) {
+            this->depth_server->close();
+            this->depth_server = 0;
+        }
+
+        if (this->luminance_server) {
+            this->luminance_server->close();
+            this->luminance_server = 0;
+        }
+
+        if (this->colourmap_server) {
+            this->colourmap_server->close ();
+            this->colourmap_server = 0;
+        }
+
+        if (this->observations_server) {
+            this->observations_server->close();
+            this->observations_server = 0;
+        }
+
+        if (this->rewards_server) {
+            this->rewards_server->close();
+            this->rewards_server = 0;
+
+        }
+
+        if (this->mission_control_server) {
+            this->mission_control_server->close();
+            this->mission_control_server = 0;
+        }
     }
 
     void AgentHost::closeServers()

--- a/Malmo/src/StringServer.h
+++ b/Malmo/src/StringServer.h
@@ -70,7 +70,10 @@ namespace malmo
             void handleMessage(const TimestampedUnsignedCharVector message);
 
             boost::function<void(const TimestampedString string_message)> handle_string;
-            TCPServer server;
+            boost::asio::io_service& io_service;
+            int port;
+            const std::string log_name;
+            boost::shared_ptr<TCPServer> server;
             std::ofstream writer;
             boost::mutex write_mutex;
 

--- a/Malmo/src/TCPServer.cpp
+++ b/Malmo/src/TCPServer.cpp
@@ -25,6 +25,7 @@
 #include <boost/bind.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/thread/thread.hpp>
 using boost::asio::ip::tcp;
 
 // STL:
@@ -63,6 +64,10 @@ namespace malmo
     void TCPServer::close() {
         this->closing = true;
         this->acceptor->close();
+        if (this->connection != nullptr) {
+            this->connection.get()->getSocket().close();
+        }
+        // Allow time to drain: boost::this_thread::sleep(boost::posix_time::seconds(1));
     }
 
     void TCPServer::confirmWithFixedReply(std::string reply)
@@ -83,26 +88,25 @@ namespace malmo
                 this->onMessageReceived(msg);
         };
 
-        boost::shared_ptr<TCPConnection> new_connection = TCPConnection::create(
+        this->connection = TCPConnection::create(
             this->acceptor->get_io_service(),
             deliverMsgIfNotClosed,
             this->expect_size_header,
             this->log_name
         );
-            
-        if( this->confirm_with_fixed_reply )
-            new_connection->confirmWithFixedReply( this->fixed_reply );
 
-        this->acceptor->async_accept(new_connection->getSocket(),
-            boost::bind(&TCPServer::handleAccept,
-            this,
-            new_connection,
-            boost::asio::placeholders::error));
+        if (this->confirm_with_fixed_reply)
+            this->connection->confirmWithFixedReply(this->fixed_reply);
+
+        if (!this->closing) {
+            this->acceptor->async_accept(this->connection->getSocket(),
+                boost::bind(&TCPServer::handleAccept,
+                this,
+                boost::asio::placeholders::error));
+        }
     }
     
-    void TCPServer::handleAccept(
-        boost::shared_ptr<TCPConnection> new_connection,
-        const boost::system::error_code& error)
+    void TCPServer::handleAccept(const boost::system::error_code& error)
     {
         // On closing or on error release scope of async io processing which can be us. 
         
@@ -110,18 +114,19 @@ namespace malmo
         {
             if (this->closing)
             {
-                new_connection.get()->getSocket().close();
+                this->connection.get()->getSocket().close();
                 if (this->scope != nullptr) 
                     this->scope->release();
             }
             else {
-                new_connection->read();
+                this->connection->read();
                 if (!this->closing)
                 {
                     this->startAccept();
                 }
                 else
                 {
+                    this->connection.get()->getSocket().close();
                     if (this->scope != nullptr)
                         this->scope->release();
                 }

--- a/Malmo/src/TCPServer.cpp
+++ b/Malmo/src/TCPServer.cpp
@@ -25,7 +25,6 @@
 #include <boost/bind.hpp>
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/thread/thread.hpp>
 using boost::asio::ip::tcp;
 
 // STL:
@@ -67,7 +66,6 @@ namespace malmo
         if (this->connection != nullptr) {
             this->connection.get()->getSocket().close();
         }
-        // Allow time to drain: boost::this_thread::sleep(boost::posix_time::seconds(1));
     }
 
     void TCPServer::confirmWithFixedReply(std::string reply)

--- a/Malmo/src/TCPServer.h
+++ b/Malmo/src/TCPServer.h
@@ -59,9 +59,7 @@ namespace malmo
 
             virtual void startAccept();
 
-            void handleAccept(
-                const boost::system::error_code& error
-            );
+            void handleAccept(const boost::system::error_code& error);
 
             void bindToPort(boost::asio::io_service& io_service, int port);
             void bindToRandomPortInRange(boost::asio::io_service& io_service, int port_min, int port_max);

--- a/Malmo/src/TCPServer.h
+++ b/Malmo/src/TCPServer.h
@@ -60,7 +60,6 @@ namespace malmo
             virtual void startAccept();
 
             void handleAccept(
-                boost::shared_ptr<TCPConnection> new_connection,
                 const boost::system::error_code& error
             );
 
@@ -71,6 +70,7 @@ namespace malmo
             
             boost::function<void(const TimestampedUnsignedCharVector) > onMessageReceived;
             
+            boost::shared_ptr<TCPConnection> connection;
             bool confirm_with_fixed_reply;
             std::string fixed_reply;
             bool expect_size_header;

--- a/Malmo/src/VideoServer.h
+++ b/Malmo/src/VideoServer.h
@@ -95,7 +95,9 @@ namespace malmo
             short channels;
             TimestampedVideoFrame::Transform transform;
             TimestampedVideoFrame::FrameType frametype;
-            TCPServer server;
+            boost::shared_ptr<TCPServer> server;
+            boost::asio::io_service& io_service;
+            int port;
             std::vector<std::unique_ptr<IFrameWriter>> writers;
 
             // diagnostics:

--- a/Malmo/test/CppTests/test_persistence.cpp
+++ b/Malmo/test/CppTests/test_persistence.cpp
@@ -150,13 +150,14 @@ int runAgentHost(std::string filename)
     boost::asio::io_service io_service;
     
     boost::shared_ptr<StringServer> clientMissionControlServer = boost::make_shared<StringServer>(io_service, client_info.control_port, handleControlMessages, "test_mission_control");
+    clientMissionControlServer->start(clientMissionControlServer);
     clientMissionControlServer->confirmWithFixedReply( "MALMOOK" );
     clientMissionControlServer->expectSizeHeader(false);
-    clientMissionControlServer->start(clientMissionControlServer);
+   
     
     boost::shared_ptr<StringServer> clientCommandsServer = boost::make_shared<StringServer>( io_service, commands_port, handleCommandMessages, "test_commands");
-    clientCommandsServer->expectSizeHeader(false);
     clientCommandsServer->start(clientCommandsServer);
+    clientCommandsServer->expectSizeHeader(false);
 
     boost::thread bt(boost::bind(&boost::asio::io_service::run, &io_service));
 

--- a/Malmo/test/CppTests/test_string_server.cpp
+++ b/Malmo/test/CppTests/test_string_server.cpp
@@ -56,9 +56,10 @@ bool testStringServer( bool withReply )
     std::cout << "Starting server.." << std::endl;
     boost::asio::io_service io_service;
     boost::shared_ptr<StringServer> server = boost::make_shared<StringServer>( io_service, 0, onMessageReceived, "test" );
+    server->start(server);
     if( withReply )
         server->confirmWithFixedReply( expected_reply );
-    server->start(server);
+   
     boost::thread bt(boost::bind(&boost::asio::io_service::run, &io_service));
     
     const int num_messages_sent = 100;

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
@@ -1599,7 +1599,10 @@ public class ClientStateMachine extends StateMachine implements IMalmoMessageLis
                 // Must display the GUI or Minecraft will attempt to access a non-existent player in the client tick.
                 Minecraft.getMinecraft().displayGuiScreen(new GuiMainMenu());
 
-                Thread.sleep(10000);
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException ie) {
+                }
             }
         }
 

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
@@ -1598,6 +1598,8 @@ public class ClientStateMachine extends StateMachine implements IMalmoMessageLis
                 Minecraft.getMinecraft().loadWorld((WorldClient) null);
                 // Must display the GUI or Minecraft will attempt to access a non-existent player in the client tick.
                 Minecraft.getMinecraft().displayGuiScreen(new GuiMainMenu());
+
+                Thread.sleep(10000);
             }
         }
 

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Client/ClientStateMachine.java
@@ -1600,6 +1600,7 @@ public class ClientStateMachine extends StateMachine implements IMalmoMessageLis
                 // Must display the GUI or Minecraft will attempt to access a non-existent player in the client tick.
                 Minecraft.getMinecraft().displayGuiScreen(new GuiMainMenu());
 
+                // Allow shutdown messages to flow through.
                 try {
                     Thread.sleep(10000);
                 } catch (InterruptedException ie) {

--- a/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
+++ b/Minecraft/src/main/java/com/microsoft/Malmo/Client/MalmoEnvServer.java
@@ -342,9 +342,13 @@ public class MalmoEnvServer implements IWantToQuit {
         byte[] replyBytes = new byte[hdr];
         dis.readFully(replyBytes);
 
-        if (new String(replyBytes).equals("MALMOOK")) {
+        String replyStr = new String(replyBytes);
+        if (replyStr.equals("MALMOOK")) {
             TCPUtils.Log(Level.INFO, "MalmoEnvServer Mission starting ...");
             return true;
+        } else if (replyStr.equals("MALMOBUSY")) {
+            TCPUtils.Log(Level.INFO, "MalmoEnvServer Busy - I want to quit");
+            this.envState.quit = true;
         }
         return false;
     }


### PR DESCRIPTION
TCP ports remain open after agent host close.
Shutdown messages get delivered late.
De-allocation issues on MacOS.