### PR TITLE
Update Malmo/src/PythonWrapper/CMakeLists.txt

### DIFF
--- a/Malmo/src/PythonWrapper/CMakeLists.txt
+++ b/Malmo/src/PythonWrapper/CMakeLists.txt
@@ -22,7 +22,7 @@ set( CPP_SOURCES
 )
 
 set( OTHER_FILES
-  ${CMAKE_SOURCE_DIR}/Malmo/samples/Python_examples/tutorial_6.xml
+  ${PROJECT_SOURCE_DIR}/Malmo/samples/Python_examples/tutorial_6.xml
 )
 
 python_add_module( MalmoPython SHARED ${CPP_SOURCES} )


### PR DESCRIPTION
This commit updates Malmo/src/PythonWrapper/CMakeLists.txt to use PROJECT_SOURCE_DIR instead of CMAKE_SOURCE_DIR, for easier inclusion in other CMake-based projects.