### PR TITLE
Add missing STL stack include

### DIFF
--- a/Malmo/src/PosixFrameWriter.h
+++ b/Malmo/src/PosixFrameWriter.h
@@ -23,6 +23,9 @@
 // Local:
 #include "VideoFrameWriter.h"
 
+// STL:
+#include <stack>
+
 namespace malmo
 {
     class PosixFrameWriter : public VideoFrameWriter


### PR DESCRIPTION
Otherwise, on gcc 10.2.0, it complains with the error message:

```
In file included from /home/nilg/MalmoPlatform/Malmo/src/VideoFrameWriter.cpp:27:
/home/nilg/MalmoPlatform/Malmo/src/PosixFrameWriter.h:48:21: error: ‘stack’ in namespace ‘std’ does not name a template type
   48 |         static std::stack<pid_fd> child_process_stack;
      |                     ^~~~~
In file included from /home/nilg/MalmoPlatform/Malmo/src/VideoFrameWriter.cpp:27:
/home/nilg/MalmoPlatform/Malmo/src/PosixFrameWriter.h:1:1: note: ‘std::stack’ is defined in header ‘<stack>’; did you forget to ‘#include <stack>’?
  +++ |+#include <stack>
    1 | // --------------------------------------------------------------------------------------------------
```