### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,10 @@ matrix:
       compiler: clang
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then travis_wait 40 .travis/ci_macosx.sh      ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then travis_wait 40 .travis/ci_ubuntu14.04.sh ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then .travis/ci_macosx.sh      ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then .travis/ci_ubuntu14.04.sh ; fi
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
